### PR TITLE
Improve markdown

### DIFF
--- a/instructor-guide/docs/00-What-is-egghead.md
+++ b/instructor-guide/docs/00-What-is-egghead.md
@@ -1,4 +1,4 @@
-# 00 - What is egghead?
+## What is egghead?
 egghead.io is a community where web developers learn from each other through short lessons and courses teaching the tools of our trade.
 
 Our instructors hail from every continent but Antartica. (That’s next.) egghead instructors are platform-agnostic, learning-enthusiastic, and badass by definition, however they define it.
@@ -14,7 +14,7 @@ Have 10 spare minutes? You can learn a skill.
 
 Have a skill? You can be an instructor (and [get paid](https://paper.dropbox.com/doc/FRoGSwr8LPNxoyd6ViWiE) for it).
 
-## What are lessons like?
+### What are lessons like?
 
 egghead lessons are bite-sized, practice-ready video tutorials for busy web developers.
 
@@ -23,7 +23,7 @@ Every egghead lesson consists of a single screencast that’s 1–10 minutes lon
 There’s an art to [teaching concepts as an egghead instructor](https://paper.dropbox.com/doc/06-How-to-instruct-z72d73FEvscPjJwwGDLIS), but you don’t need to be nervous. Or shy. Just be yourself, no matter who you are or what your lesson is about. Just be sure to [edit out](https://paper.dropbox.com/doc/04-Edit-your-lesson-MeWShbq74RFNerLauz5AH) the “umm”s and “uhh”s.
 
 
-## What makes egghead different?
+### What makes egghead different?
 
 We believe variety is the spice of learning. No two people learn the same way, so no one person can be the de facto teacher of anything. You’ll find two, sometimes three egghead lessons covering the very same topic. If one lesson doesn’t offer a breakthrough moment for a learner, we bet another will.
 
@@ -34,12 +34,12 @@ We believe variety is the spice of learning. No two people learn the same way, s
 So if your dream [topic is already taken](https://paper.dropbox.com/doc/03-What-if-a-lesson-already-exists-EkgS7A0FsyKtftFTs2Yr1), it’s not taken at all. Go ahead, press record, and share what you know from your perspective.
 
 
-## Who should be an instructor?
+### Who should be an instructor?
 
 You should be an instructor. [Here’s why.](https://paper.dropbox.com/doc/01-Why-be-an-instructor-u68jBYc1Ly1F5wWoi4jXT)
 
 
-## How do I get started?
+### How do I get started?
 
 If we sent you an invitation, we’re so glad you’re learning more. If you haven’t accepted yet, sign up right here right now. After you finish reading this guide and know egghead style like the back of your hand, you’ll record a [30-second lesson snippet](https://paper.dropbox.com/doc/04-Create-your-30-second-lesson-0wwXUm3M924ym22w3ZpPZ) that we’ll help you shape into your first published lesson.
 
@@ -48,7 +48,7 @@ If we *haven’t* sent you an invitation, we’re equally glad to see you. You c
 [More on creating and uploading your 30-second videos](https://paper.dropbox.com/doc/04-Create-your-30-second-lesson-0wwXUm3M924ym22w3ZpPZ)
 
 
-## No more questions?
+### No more questions?
 
 Great! We have more answers anyway.
 

--- a/instructor-guide/docs/00-What-is-egghead.md
+++ b/instructor-guide/docs/00-What-is-egghead.md
@@ -1,5 +1,5 @@
 # 00 - What is egghead?
-egghead.io is a community where web developers learn from each other through short lessons and courses teaching the tools of our trade. 
+egghead.io is a community where web developers learn from each other through short lessons and courses teaching the tools of our trade.
 
 Our instructors hail from every continent but Antartica. (That’s next.) egghead instructors are platform-agnostic, learning-enthusiastic, and badass by definition, however they define it.
 
@@ -10,13 +10,13 @@ egghead was created by a small team of web developers who know how essential it 
 
 
 
-Have 10 spare minutes? You can learn a skill. 
+Have 10 spare minutes? You can learn a skill.
 
 Have a skill? You can be an instructor (and [get paid](https://paper.dropbox.com/doc/FRoGSwr8LPNxoyd6ViWiE) for it).
 
 ## What are lessons like?
 
-egghead lessons are bite-sized, practice-ready video tutorials for busy web developers. 
+egghead lessons are bite-sized, practice-ready video tutorials for busy web developers.
 
 Every egghead lesson consists of a single screencast that’s 1–10 minutes long. You’ll record your screen as you talk through [a code example](https://paper.dropbox.com/doc/05-Create-your-code-example-cDZZONYRKCLyHsIKaIuSY), just like you’re explaining how you solved a problem to a coworker. The goal of each lesson is to give learners a specific piece of knowledge they can use right away.
 
@@ -25,14 +25,13 @@ There’s an art to [teaching concepts as an egghead instructor](https://paper.d
 
 ## What makes egghead different?
 
-We believe variety is the spice of learning. No two people learn the same way, so no one person can be the de facto teacher of anything. You’ll find two, sometimes three egghead lessons covering the very same topic. If one lesson doesn’t offer a breakthrough moment for a learner, we bet another will. 
+We believe variety is the spice of learning. No two people learn the same way, so no one person can be the de facto teacher of anything. You’ll find two, sometimes three egghead lessons covering the very same topic. If one lesson doesn’t offer a breakthrough moment for a learner, we bet another will.
 
 
 ![02_diverse_instructors](https://d2mxuefqeaa7sj.cloudfront.net/s_5998CB8F4ACAE04353DF55D78578CAC9F495218C5B780DCB121ECA0E8390328B_1530529160184_file.png)
 
-**
 
-So if your dream [topic is already taken](https://paper.dropbox.com/doc/03-What-if-a-lesson-already-exists-EkgS7A0FsyKtftFTs2Yr1), it’s not taken at all. Go ahead, press record, and share what you know from your perspective. 
+So if your dream [topic is already taken](https://paper.dropbox.com/doc/03-What-if-a-lesson-already-exists-EkgS7A0FsyKtftFTs2Yr1), it’s not taken at all. Go ahead, press record, and share what you know from your perspective.
 
 
 ## Who should be an instructor?
@@ -44,7 +43,7 @@ You should be an instructor. [Here’s why.](https://paper.dropbox.com/doc/01-Wh
 
 If we sent you an invitation, we’re so glad you’re learning more. If you haven’t accepted yet, sign up right here right now. After you finish reading this guide and know egghead style like the back of your hand, you’ll record a [30-second lesson snippet](https://paper.dropbox.com/doc/04-Create-your-30-second-lesson-0wwXUm3M924ym22w3ZpPZ) that we’ll help you shape into your first published lesson.
 
-If we *haven’t* sent you an invitation, we’re equally glad to see you. You can audition by [recording a 30-second lesson snippet](https://paper.dropbox.com/doc/04-Create-your-30-second-lesson-0wwXUm3M924ym22w3ZpPZ). (No pressure, deep breath.) Read through this guide, hit record, and introduce us to your skills and way of doing things. 
+If we *haven’t* sent you an invitation, we’re equally glad to see you. You can audition by [recording a 30-second lesson snippet](https://paper.dropbox.com/doc/04-Create-your-30-second-lesson-0wwXUm3M924ym22w3ZpPZ). (No pressure, deep breath.) Read through this guide, hit record, and introduce us to your skills and way of doing things.
 
 [More on creating and uploading your 30-second videos](https://paper.dropbox.com/doc/04-Create-your-30-second-lesson-0wwXUm3M924ym22w3ZpPZ)
 

--- a/instructor-guide/docs/00-What-is-egghead.md
+++ b/instructor-guide/docs/00-What-is-egghead.md
@@ -51,6 +51,3 @@ If we *haven’t* sent you an invitation, we’re equally glad to see you. You c
 ### No more questions?
 
 Great! We have more answers anyway.
-
-Next up → [Why be an instructor?](https://paper.dropbox.com/doc/01-Why-be-an-instructor-u68jBYc1Ly1F5wWoi4jXT)
-

--- a/instructor-guide/docs/01-Getting-started-as-an-egghead-instructor/01-Why-be-an-instructor.md
+++ b/instructor-guide/docs/01-Getting-started-as-an-egghead-instructor/01-Why-be-an-instructor.md
@@ -1,10 +1,10 @@
-# 01 - Why be an instructor? 
+## Why be an instructor?
 We get it. The last thing you need is another commitment. (You probably see the word “commit” in your sleep.) Good news: egghead instructors have zero obligations. It’s a lowkey side hustle that can seriously pay off.
 
 
-## You get paid
+### You get paid
 
-egghead instructors [get paid](https://paper.dropbox.com/doc/07-Getting-paid-FRoGSwr8LPNxoyd6ViWiE) every time someone watches one of your published lessons. More accurately, we pay you monthly based on your views for the preceding month. We market our content quite a bit, but feel free to share your lessons widely. 
+egghead instructors [get paid](https://paper.dropbox.com/doc/07-Getting-paid-FRoGSwr8LPNxoyd6ViWiE) every time someone watches one of your published lessons. More accurately, we pay you monthly based on your views for the preceding month. We market our content quite a bit, but feel free to share your lessons widely.
 
 
 ![03_eggo_raining_money](https://d2mxuefqeaa7sj.cloudfront.net/s_12F044CEE45D0F4D2D29675E09CDBFF3658A88B44F244372E9483DF7DAEBE7CC_1530529694287_file.png)
@@ -13,17 +13,17 @@ egghead instructors [get paid](https://paper.dropbox.com/doc/07-Getting-paid-FRo
 The more content you publish, the more money you’re likely to make. [More on payment](https://paper.dropbox.com/doc/07-Getting-paid-FRoGSwr8LPNxoyd6ViWiE).
 
 
-## You’re an expert
+### You’re an expert
 
 You heard us! You’re an expert. egghead instructors aren’t necessarily senior developers or technology directors (though some are). They’re just people who love writing code. You’re an expert when you share knowledge other people are looking for. So share it!
 
 
-## Cement your knowledge
+### Cement your knowledge
 
 Explaining something helps you understand it better. If you’re learning a new skill or framework, there’s no better way to nail it than to record yourself talking about it (and re-record and edit until the holes in your logic disappear). Pop quiz yourself and make some money while you’re at it.
 
 
-## Make career moves
+### Make career moves
 
 egghead instructor looks 👍 on a resume. Published lessons are portfolio gold. egghead gives you a platform—and all you need to do is give your knowledge a voice. We’ll amplify it for you.
 
@@ -33,14 +33,14 @@ egghead instructor looks 👍 on a resume. Published lessons are portfolio gold.
 
 
 
-## Get egghead.io access for life
+### Get egghead.io access for life
 
 Here’s a serious perk: Every egghead instructor gets a lifetime membership to egghead.io with access to all of our premium lessons and courses. That’s a lot of learning to do, with lots more to come.
 
 
-## Work with good people
+### Work with good people
 
-You should always do your due diligence before partnering with any organization. But we give you our word: egghead is a low-key company whose sole focus is making web developers better at what they do. 
+You should always do your due diligence before partnering with any organization. But we give you our word: egghead is a low-key company whose sole focus is making web developers better at what they do.
 
 Most of us at egghead HQ are developers too, so we know how busy you are. [We’ll support you](https://paper.dropbox.com/doc/03-Meeting-your-coach-48kv2z4NI0EXDNAAdxN09), we won’t give you deadlines (seriously—you produce content only when you want to), and we’ll [pay you](https://paper.dropbox.com/doc/07-Getting-paid-FRoGSwr8LPNxoyd6ViWiE) fairly and quickly. Honestly, egghead is the company we always wanted to work with, so we created it for ourselves and for all the smart, badass developers out there.
 

--- a/instructor-guide/docs/01-Getting-started-as-an-egghead-instructor/01-Why-be-an-instructor.md
+++ b/instructor-guide/docs/01-Getting-started-as-an-egghead-instructor/01-Why-be-an-instructor.md
@@ -43,6 +43,3 @@ Here’s a serious perk: Every egghead instructor gets a lifetime membership to 
 You should always do your due diligence before partnering with any organization. But we give you our word: egghead is a low-key company whose sole focus is making web developers better at what they do.
 
 Most of us at egghead HQ are developers too, so we know how busy you are. [We’ll support you](https://paper.dropbox.com/doc/03-Meeting-your-coach-48kv2z4NI0EXDNAAdxN09), we won’t give you deadlines (seriously—you produce content only when you want to), and we’ll [pay you](https://paper.dropbox.com/doc/07-Getting-paid-FRoGSwr8LPNxoyd6ViWiE) fairly and quickly. Honestly, egghead is the company we always wanted to work with, so we created it for ourselves and for all the smart, badass developers out there.
-
-Next up → [Joining Slack](https://paper.dropbox.com/doc/OK2qnPz6WWGvITGMDTeCE)
-

--- a/instructor-guide/docs/01-Getting-started-as-an-egghead-instructor/02-Joining-Slack.md
+++ b/instructor-guide/docs/01-Getting-started-as-an-egghead-instructor/02-Joining-Slack.md
@@ -1,10 +1,10 @@
-# 02 - **Joining Slack**
+## Joining Slack
 
 
 ![05_slack_eggos](https://d2mxuefqeaa7sj.cloudfront.net/s_84C94660750D9DC6D746B8A16B4EEF8773037FF7C40B1F1779FA68D2FBEDCA06_1530529776845_file.png)
 
 
-Slack is where we communicate. 
+Slack is where we communicate.
 
 Once you’ve [signed up](http://egghead.io/) for egghead and created your instructor profile, you’ll receive an invitation to [our Slack channel](https://paper.dropbox.com/doc/01-egghead-on-Slack-VSi6vqVpXCmyahsf660Y2). That’s where you can meet other instructors from all over the world, talk shop, and get all the support you need from the egghead team. As an instructor, you have access to the egghead Slack for life. Bring your best emoji game.
 
@@ -14,7 +14,7 @@ Once you’ve [signed up](http://egghead.io/) for egghead and created your instr
 
 Right when you join Slack, we’ll create your private instructor channel. That’s where we’ll share feedback with you, hash out lesson ideas, and answer any questions you have.
 
-When in doubt, Slack! 
+When in doubt, Slack!
 
 Next up → [Meeting your coach](https://paper.dropbox.com/doc/48kv2z4NI0EXDNAAdxN09)
 

--- a/instructor-guide/docs/01-Getting-started-as-an-egghead-instructor/02-Joining-Slack.md
+++ b/instructor-guide/docs/01-Getting-started-as-an-egghead-instructor/02-Joining-Slack.md
@@ -15,6 +15,3 @@ Once you’ve [signed up](http://egghead.io/) for egghead and created your instr
 Right when you join Slack, we’ll create your private instructor channel. That’s where we’ll share feedback with you, hash out lesson ideas, and answer any questions you have.
 
 When in doubt, Slack!
-
-Next up → [Meeting your coach](https://paper.dropbox.com/doc/48kv2z4NI0EXDNAAdxN09)
-

--- a/instructor-guide/docs/01-Getting-started-as-an-egghead-instructor/03-Meeting-your-coach.md
+++ b/instructor-guide/docs/01-Getting-started-as-an-egghead-instructor/03-Meeting-your-coach.md
@@ -1,7 +1,7 @@
-# 03 - Meeting your coach
+## Meeting your coach
 Your success as an instructor is the #1 priority at egghead—and we know success doesn’t come without support. You’ll need some guidance to create the world-class screencasts our members expect. That’s why we pair you with an egghead coach right when you start.
 
-Your coach is a seasoned instructor who will help you nail egghead style through ongoing support, feedback, and brainstorming. Got questions? #ask! Big stuff, little stuff, rough drafts, fire away. 
+Your coach is a seasoned instructor who will help you nail egghead style through ongoing support, feedback, and brainstorming. Got questions? #ask! Big stuff, little stuff, rough drafts, fire away.
 
 
 ![07_coach_gif](https://media.giphy.com/media/PAYR5Ar3XpJJu/giphy.gif)
@@ -11,14 +11,14 @@ Slack with your coach to:
 
 - Brainstorm [lesson ideas](https://paper.dropbox.com/doc/02-What-should-you-teach-ebbyW6MTdvsU8GPCkJUn3)
 - Solidify the theme, scope, and goals of a code example
-- Get a second pair of eyes before uploading screencasts 
+- Get a second pair of eyes before uploading screencasts
 - Talk through feedback
-- Get answers on administrative stuff like contracts, equipment, etc. 
+- Get answers on administrative stuff like contracts, equipment, etc.
 
-Even after you’ve published a few lessons, your coach is available whenever you need them. 
+Even after you’ve published a few lessons, your coach is available whenever you need them.
 
 Plus, you can reach out to egghead's founders John Lindquist (@john) and Joel Hooks (@joel) with any questions or concerns. John and Joel are 100% dedicated to you and the rest of the egghead instructors. Slack us!
 
-Next up → [Create your 30-second lesson](https://paper.dropbox.com/doc/0wwXUm3M924ym22w3ZpPZ) 
+Next up → [Create your 30-second lesson](https://paper.dropbox.com/doc/0wwXUm3M924ym22w3ZpPZ)
 
 

--- a/instructor-guide/docs/01-Getting-started-as-an-egghead-instructor/03-Meeting-your-coach.md
+++ b/instructor-guide/docs/01-Getting-started-as-an-egghead-instructor/03-Meeting-your-coach.md
@@ -19,6 +19,3 @@ Even after you’ve published a few lessons, your coach is available whenever yo
 
 Plus, you can reach out to egghead's founders John Lindquist (@john) and Joel Hooks (@joel) with any questions or concerns. John and Joel are 100% dedicated to you and the rest of the egghead instructors. Slack us!
 
-Next up → [Create your 30-second lesson](https://paper.dropbox.com/doc/0wwXUm3M924ym22w3ZpPZ)
-
-

--- a/instructor-guide/docs/01-Getting-started-as-an-egghead-instructor/04-Create-your-30-second-lesson.md
+++ b/instructor-guide/docs/01-Getting-started-as-an-egghead-instructor/04-Create-your-30-second-lesson.md
@@ -1,10 +1,10 @@
-# 04 - **Create your 30-second lesson**
+## 04 - Create your 30-second lesson
 
 We want to help new instructors get the hang of egghead style as fast as possible. We know you won’t nail it right away—that’s okay! That’s expected!—so instead of creating an entire lesson, we ask you to record a 30-second video first. That snippet will tell us plenty, and we’ll be able to give you feedback on your [code example](https://paper.dropbox.com/doc/05-Create-your-code-example-cDZZONYRKCLyHsIKaIuSY), [instruction style](https://paper.dropbox.com/doc/06-How-to-instruct-z72d73FEvscPjJwwGDLIS), and the [technical stuff](https://paper.dropbox.com/folder/show/04-Screencasting-tips-e.1gg8YzoPEhbTkrhvQwJ2zz3VfffmW8lGwgJoc5jCIvamKrIozeHB).
 
 ![08_30second_lesson](https://d2mxuefqeaa7sj.cloudfront.net/s_9838C555F24EB65660F8595157C5BEE00A2628AF3D89A31309BA4CB5DEE58428_1530530122820_file.png)
 
-## What we're looking for
+### What we're looking for
 
 Don't be too concerned about subject matter, audio, or video quality at this point. You want to dial in your:
 
@@ -17,7 +17,7 @@ Don't be too concerned about subject matter, audio, or video quality at this poi
 
 Our [technical guide](https://paper.dropbox.com/folder/show/04-Screencasting-tips-e.1gg8YzoPEhbTkrhvQwJ2zz3VfffmW8lGwgJoc5jCIvamKrIozeHB) has you all the details you need to confidently press record. Think you have it figured out? Share a screenshot of your screen setup on [Slack](https://paper.dropbox.com/doc/01-egghead-on-Slack-VSi6vqVpXCmyahsf660Y2).
 
-## Pick a topic
+### Pick a topic
 
 ...but of course, you’ll need to cover something specific. Since your video isn't intended for publication, keep it simple. No need to solve the internet just to impress us! Just pick a topic other web developers would find interesting, in the language of your choice. Python, Ruby, Rust, whatever you’re feeling.
 
@@ -33,7 +33,7 @@ Some quick ideas:
 
 Need help? Hit us up in your private [Slack channel](https://paper.dropbox.com/doc/01-egghead-on-Slack-VSi6vqVpXCmyahsf660Y2).
 
-## Start with the code
+### Start with the code
 
 ![11_start_with_code](https://d2mxuefqeaa7sj.cloudfront.net/s_9838C555F24EB65660F8595157C5BEE00A2628AF3D89A31309BA4CB5DEE58428_1530530275859_file.png)
 
@@ -41,7 +41,7 @@ Before you record your clip, create your [example](https://paper.dropbox.com/doc
 
 Need a gut check? Share your code on Slack using a [Github gist](https://paper.dropbox.com/doc/05-Sharing-your-code-XPt8sCs1hyoeAEuyK8aQr).
 
-## Hit record
+### Hit record
 
 You've got a topic. You've got the code. Your screen is setup and ready to go.
 
@@ -49,7 +49,7 @@ Now, you need to record your screen as you take your code from its start state t
 
 Don't worry about it. Don't edit it. Don't fuss over it. Just let it start the conversation.
 
-## Share your recording on egghead.io
+### Share your recording on egghead.io
 
 You can upload your video by submitting an application on [egghead.io](http://egghead.io).
 

--- a/instructor-guide/docs/01-Getting-started-as-an-egghead-instructor/04-Create-your-30-second-lesson.md
+++ b/instructor-guide/docs/01-Getting-started-as-an-egghead-instructor/04-Create-your-30-second-lesson.md
@@ -65,4 +65,3 @@ We hope you’ll turn this snippet into your first published lesson, or you migh
 
 Pro tip: You’ll have a better chance of submitting a 👍 30-second video and getting invited to egghead if you read this whole guide. So keep reading! Then show us what you got!
 
-Next up → [Getting feedback on your video](https://paper.dropbox.com/doc/XAWAJxUQNnXO69QWntwp3)

--- a/instructor-guide/docs/01-Getting-started-as-an-egghead-instructor/04-Create-your-30-second-lesson.md
+++ b/instructor-guide/docs/01-Getting-started-as-an-egghead-instructor/04-Create-your-30-second-lesson.md
@@ -1,4 +1,4 @@
-## 04 - Create your 30-second lesson
+## Create your 30-second lesson
 
 We want to help new instructors get the hang of egghead style as fast as possible. We know you won’t nail it right away—that’s okay! That’s expected!—so instead of creating an entire lesson, we ask you to record a 30-second video first. That snippet will tell us plenty, and we’ll be able to give you feedback on your [code example](https://paper.dropbox.com/doc/05-Create-your-code-example-cDZZONYRKCLyHsIKaIuSY), [instruction style](https://paper.dropbox.com/doc/06-How-to-instruct-z72d73FEvscPjJwwGDLIS), and the [technical stuff](https://paper.dropbox.com/folder/show/04-Screencasting-tips-e.1gg8YzoPEhbTkrhvQwJ2zz3VfffmW8lGwgJoc5jCIvamKrIozeHB).
 

--- a/instructor-guide/docs/01-Getting-started-as-an-egghead-instructor/05-Getting-feedback-on-your-video.md
+++ b/instructor-guide/docs/01-Getting-started-as-an-egghead-instructor/05-Getting-feedback-on-your-video.md
@@ -1,8 +1,8 @@
-# 05 - **Getting feedback on your video**
-Think of your 30-second video as a very rough draft. It won’t be perfect—and it shouldn’t be! It’s a gut check to see how we can help steer you toward egghead style. 
+## Getting feedback on your video
+Think of your 30-second video as a very rough draft. It won’t be perfect—and it shouldn’t be! It’s a gut check to see how we can help steer you toward egghead style.
 
 
-## Questions? Just #ask.
+### Questions? Just #ask.
 
 We’re here to help you. Before you record your video, use your private Slack channel to fire over any questions or works in progress, like:
 
@@ -15,21 +15,21 @@ We’re all about supportive, ongoing feedback at egghead, so when you’re read
 
 ![An illustration would work here too 🙂](https://media1.giphy.com/media/111ebonMs90YLu/giphy.gif)
 
-## Feedback
+### Feedback
 
 Before you upload your video (if we’ve invited you to be an instructor) or tweet it at [@eggheadio](https://twitter.com/eggheadio) (if you’re auditioning), ask yourself:
 
 
 - Is my screen set to 1280x720 (720p)? (In HiDPI, if possible?)
-- Is my code example easy to understand? 
-- Did I guide the viewer’s eyes with the mouse? 
-- Did I use those 30 seconds to share useful insights? 
+- Is my code example easy to understand?
+- Did I guide the viewer’s eyes with the mouse?
+- Did I use those 30 seconds to share useful insights?
 
-We’ll use those questions to guide our feedback, which we’ll share with you over Slack. 
+We’ll use those questions to guide our feedback, which we’ll share with you over Slack.
 
-After that, we may go through a few rounds of rerecording and feedback until we feel you’re ready to go off and record your first lesson. 
+After that, we may go through a few rounds of rerecording and feedback until we feel you’re ready to go off and record your first lesson.
 
 Remember: We want you to succeed. We want you to absolutely crush it. Feedback—especially right when you start with egghead—will help you get there.
 
-Next up → [Receiving your equipment](https://paper.dropbox.com/doc/KykT89A667Oibi8cqBdkE) [**](https://paper.dropbox.com/doc/KykT89A667Oibi8cqBdkE)
+Next up → [Receiving your equipment](https://paper.dropbox.com/doc/KykT89A667Oibi8cqBdkE) [](https://paper.dropbox.com/doc/KykT89A667Oibi8cqBdkE)
 

--- a/instructor-guide/docs/01-Getting-started-as-an-egghead-instructor/05-Getting-feedback-on-your-video.md
+++ b/instructor-guide/docs/01-Getting-started-as-an-egghead-instructor/05-Getting-feedback-on-your-video.md
@@ -30,6 +30,3 @@ We’ll use those questions to guide our feedback, which we’ll share with you 
 After that, we may go through a few rounds of rerecording and feedback until we feel you’re ready to go off and record your first lesson.
 
 Remember: We want you to succeed. We want you to absolutely crush it. Feedback—especially right when you start with egghead—will help you get there.
-
-Next up → [Receiving your equipment](https://paper.dropbox.com/doc/KykT89A667Oibi8cqBdkE) [](https://paper.dropbox.com/doc/KykT89A667Oibi8cqBdkE)
-

--- a/instructor-guide/docs/01-Getting-started-as-an-egghead-instructor/06-Receiving-your-equipment.md
+++ b/instructor-guide/docs/01-Getting-started-as-an-egghead-instructor/06-Receiving-your-equipment.md
@@ -16,5 +16,3 @@ You’ll get:
 
 Our [technical guide](https://paper.dropbox.com/doc/02-Set-up-your-audio-oyhAegdRyTG7R1IkdNajZ) covers setup and how each item works.
 
-Next up → [Getting paid](https://paper.dropbox.com/doc/FRoGSwr8LPNxoyd6ViWiE)
-

--- a/instructor-guide/docs/01-Getting-started-as-an-egghead-instructor/06-Receiving-your-equipment.md
+++ b/instructor-guide/docs/01-Getting-started-as-an-egghead-instructor/06-Receiving-your-equipment.md
@@ -1,4 +1,4 @@
-# 06 - **Receiving your equipment**
+## Receiving your equipment
 If you’re looking at your laptop and wondering how you’ll juke the microphone settings to create professional-quality sound quality...no need. We got you!
 
 Once you've created a draft lesson that is *almost* ready to be published, we’ll ship you a case packed with audio recording toys. With our compliments, of course.

--- a/instructor-guide/docs/01-Getting-started-as-an-egghead-instructor/07-Getting-paid.md
+++ b/instructor-guide/docs/01-Getting-started-as-an-egghead-instructor/07-Getting-paid.md
@@ -1,16 +1,16 @@
-# 07 - **Getting paid**
+## Getting paid
 Yes! egghead instructors make money! You receive royalties for all the views your lessons and courses get.
 
 How much you get paid can range from "lunch money" to "paying the bills!", and primarily varies with the quality and quantity of what you publish. [Courses](https://paper.dropbox.com/doc/01-Why-create-a-course-iZcSERF74YnnkF5oDYKrD) take the most effort, but they also make the most money. Even a single lesson can net you rewarding royalties for a long time; with a keyword-rich summary and title, a lesson can surface in search engine results years after it’s published.
 
-*[Illustration: Money]* 
+*[Illustration: Money]*
 
 The best way to make money is to produce interesting, useful content. Quantity is good, but quality is better. Good content sells itself.
 
-We don't produce sponsored content or run ads on a regular basis. It’s all about eyeballs. 👀 
+We don't produce sponsored content or run ads on a regular basis. It’s all about eyeballs. 👀
 
 
-## How royalties work
+### How royalties work
 
 Royalties are paid at the beginning of the month, and reflect how many 30-second segments viewers watched in the previous month. We use PayPal or direct deposit to distribute royalties.
 
@@ -25,9 +25,9 @@ The amount you’re paid depends on the overall gross subscription revenue, and 
 When you start making one-off lessons, the royalties will be small. But stick with it, keep producing, and your monthly royalties could hit four figures. Cha-ching.
 
 
-## Make more money with courses
+### Make more money with courses
 
-After you’ve made a few standalone lessons and gotten the hang of egghead, you’ll probably put on your entrepreneurial thinking cap. How can you leverage your new skills to make the cash flow? 
+After you’ve made a few standalone lessons and gotten the hang of egghead, you’ll probably put on your entrepreneurial thinking cap. How can you leverage your new skills to make the cash flow?
 
 *Courses are the bread and butter of egghead.io*. Developers looking to learn want curated chunks of information, and we’ve found that they’re willing to pay for it. Grouped lessons are more likely to be found and watched than one-off lessons, making their royalties far greater than those of standalone lessons.
 
@@ -38,7 +38,7 @@ After you’ve made a few standalone lessons and gotten the hang of egghead, you
 You won’t be crafting courses right out of the gate, but stick with it. The payoff is worth it.
 
 
-## Keeping it up
+### Keeping it up
 
 Ongoing income is the best. But it takes ongoing work.
 
@@ -48,7 +48,7 @@ Many people create a lesson or two, then stop. There are a variety of reasons pe
 - It just isn't for me.
 - It's hard AF.
 - I can't think of what to record.
-- The money’s not coming fast enough. 
+- The money’s not coming fast enough.
 
 
 ![](https://media.giphy.com/media/D3ggX9iWqOHza/giphy.gif)
@@ -60,6 +60,6 @@ Hopefully you’re already in that position, but if not, we want to help you get
 
 If you want to create a sustainable passive income stream by creating useful learning content for fellow developers, stick with us. We’ll make it happen for you.
 
-Next Chapter →  **[Creating lessons](https://paper.dropbox.com/folder/show/02-Creating-lessons-e.1gg8YzoPEhbTkrhvQwJ2zz3VfQM0GHrAFnCB2CIJpePjqONCg0lV)
+Next Chapter →  [Creating lessons](https://paper.dropbox.com/folder/show/02-Creating-lessons-e.1gg8YzoPEhbTkrhvQwJ2zz3VfQM0GHrAFnCB2CIJpePjqONCg0lV)
 Next up → [What makes a great lesson?](https://paper.dropbox.com/doc/01-What-makes-a-great-lesson-qagM68kHsKm9PwtLpnQgx)
 

--- a/instructor-guide/docs/01-Getting-started-as-an-egghead-instructor/07-Getting-paid.md
+++ b/instructor-guide/docs/01-Getting-started-as-an-egghead-instructor/07-Getting-paid.md
@@ -59,7 +59,3 @@ One of our primary motivations for creating egghead was to help smart humans get
 Hopefully you’re already in that position, but if not, we want to help you get there. We're totally obsessed, and will do everything we can to support and amplify our instructors. We're in this to have a job that we love, work with amazing, diverse people across the globe, and help people improve their lives by learning how to develop software.
 
 If you want to create a sustainable passive income stream by creating useful learning content for fellow developers, stick with us. We’ll make it happen for you.
-
-Next Chapter →  [Creating lessons](https://paper.dropbox.com/folder/show/02-Creating-lessons-e.1gg8YzoPEhbTkrhvQwJ2zz3VfQM0GHrAFnCB2CIJpePjqONCg0lV)
-Next up → [What makes a great lesson?](https://paper.dropbox.com/doc/01-What-makes-a-great-lesson-qagM68kHsKm9PwtLpnQgx)
-

--- a/instructor-guide/docs/02-Creating-lessons/01-What-makes-a-great-lesson.md
+++ b/instructor-guide/docs/02-Creating-lessons/01-What-makes-a-great-lesson.md
@@ -1,4 +1,4 @@
-# 01 - What makes a great lesson?
+## What makes a great lesson?
 
 *Illustration note: instead of links to lessons, embed the the videos.*
 
@@ -9,7 +9,7 @@ That’s what egghead learners want you to do. They’re looking for concise, ef
 In the spirit of show, don’t tell, this free course by egghead cofounder John Lindquist shows what makes a great lesson: [Record Badass Screencasts for egghead](https://egghead.io/courses/record-badass-screencasts-for-egghead-io)
 
 
-## It’s focused
+### It’s focused
 
 An egghead lesson discusses a single topic. Don’t stray—stay on point and be concise.
 
@@ -22,18 +22,18 @@ https://www.dropbox.com/s/2p6opnh0qn8r9ao/egghead-stay-on-topic.mp4?dl=0
 
 
 
-## Its title and summary are precise
+### Its title and summary are precise
 
 Writing concise titles and summaries is the best way to narrow the scope of your lesson so it’s hyper-focused on a single topic. (They’re also the best way to cash—and we mean cash—in on search terms. Mentioning relevant technologies = SEO = 💰)
 
 Your summary should quickly tell learners what they’ll gain from your lesson. You could start by writing, “In this lesson, you will learn to...” One or two sentences are 👌
 
-Your title is the summary of your summary. It should finish the thought, “How do I...” 
+Your title is the summary of your summary. It should finish the thought, “How do I...”
 
 [More on writing titles and summaries](https://paper.dropbox.com/doc/04-Write-the-title-and-summary-iVzKqXCdSUWZbV5oKOrST)
 
 
-## The code example is simple and effective
+### The code example is simple and effective
 
 [The code example](https://paper.dropbox.com/doc/05-Create-your-code-example-cDZZONYRKCLyHsIKaIuSY) is arguably the most important part of a lesson. The learner should be able to look at the difference between the *before* and *after* code to understand how you’ve applied the concept in the lesson.
 
@@ -45,7 +45,7 @@ https://www.dropbox.com/s/5fxdwvnttkxb2lr/egghead-show-then-maybe-explain.mp4?dl
 
 
 
-## It cuts intros, outros, and stage-setting
+### It cuts intros, outros, and stage-setting
 
 **No** “hi, my name is.” **No** “in the previous lesson we learned about...” Each lesson should exist on its own without any stage-setting—just like this video:
 
@@ -53,7 +53,7 @@ https://www.dropbox.com/s/5fxdwvnttkxb2lr/egghead-show-then-maybe-explain.mp4?dl
 https://www.youtube.com/watch?v=CT_OJZCYncA&
 
 
-This video doesn't talk about the chicken recipe it covered for the dinner course. It doesn’t explain why you may need a cheesecake-stuffed cookie cake. (Attending a party? Stress-baking?) It doesn’t explain what sugar, cookie dough, and ovens are for the .00001% of the population that don’t already know. It just jumps right in. 
+This video doesn't talk about the chicken recipe it covered for the dinner course. It doesn’t explain why you may need a cheesecake-stuffed cookie cake. (Attending a party? Stress-baking?) It doesn’t explain what sugar, cookie dough, and ovens are for the .00001% of the population that don’t already know. It just jumps right in.
 
 When creating your lessons, assume your viewers have working knowledge of the topics covered or will pause the video to learn on their own time. Don’t waste time in your lesson reinventing the wheel (or explaining what wheels are and why they’re helpful).
 
@@ -64,9 +64,9 @@ https://www.dropbox.com/s/6x6o608fwiwv28b/egghead-avoid-intros-and-outros.mp4?dl
 
 
 
-## It guides the eyes
+### It guides the eyes
 
-Your audience is trying to follow what you're saying. It's crucial that you keep them with you by guiding their eyes. 
+Your audience is trying to follow what you're saying. It's crucial that you keep them with you by guiding their eyes.
 
 Highlight the area of the screen you're teaching. Use the mouse to select/click/drag or anything that creates a sense of movement to tell them "You should be looking here!" Remember, this is a video, they're here for the movement, so keep it movin'!
 
@@ -77,7 +77,7 @@ https://www.dropbox.com/s/izvlyf41j6kk6kw/egghead-guide-their-eyes.mp4?dl=0
 
 
 
-## Slack us!
+### Slack us!
 
 Still foggy on egghead style? Your coach (and the rest of us at egghead HQ) are here to clear the air. #ask!
 

--- a/instructor-guide/docs/02-Creating-lessons/01-What-makes-a-great-lesson.md
+++ b/instructor-guide/docs/02-Creating-lessons/01-What-makes-a-great-lesson.md
@@ -80,6 +80,3 @@ https://www.dropbox.com/s/izvlyf41j6kk6kw/egghead-guide-their-eyes.mp4?dl=0
 ### Slack us!
 
 Still foggy on egghead style? Your coach (and the rest of us at egghead HQ) are here to clear the air. #ask!
-
-Next up → [What should you teach?](https://paper.dropbox.com/doc/02-What-should-you-teach-ebbyW6MTdvsU8GPCkJUn3)
-

--- a/instructor-guide/docs/02-Creating-lessons/02-What-should-you-teach.md
+++ b/instructor-guide/docs/02-Creating-lessons/02-What-should-you-teach.md
@@ -73,6 +73,3 @@ We have zero qualms about repeating topics. Actually, [we encourage it](https://
 Truly stuck? #ask us for a jumpstart, or come up with some ideas and we’ll pare them down.
 
 Remember: Think small. Don’t explain how to build the internet. Just a small corner of it.
-
-Next up → [What if that lesson already exists?](https://paper.dropbox.com/doc/03-What-if-a-lesson-already-exists-EkgS7A0FsyKtftFTs2Yr1)
-

--- a/instructor-guide/docs/02-Creating-lessons/02-What-should-you-teach.md
+++ b/instructor-guide/docs/02-Creating-lessons/02-What-should-you-teach.md
@@ -1,7 +1,7 @@
-# 02 - **What should you teach?**
+## What should you teach?
 *Quick! Come up with an idea!* Unfortunately, it doesn’t work that way.
 
-As with writing or drawing, instructing about *anything* can be daunting. *Anything* is too big a concept to wrap your head around. That’s why we need prompts. 
+As with writing or drawing, instructing about *anything* can be daunting. *Anything* is too big a concept to wrap your head around. That’s why we need prompts.
 
 Tell someone with writer’s block, “Describe your favorite food.” An hour later they’ll have an essay on cheeseburgers. Tell an artist, “Draw a cheeseburger,” and they’ll draw you a cheeseburger good enough to eat (and write about).
 
@@ -10,7 +10,7 @@ Tell someone with writer’s block, “Describe your favorite food.” An hour l
 The same goes for egghead lessons. Give yourself a prompt. Make it small and specific.
 
 
-## Finding ideas
+### Finding ideas
 
 You’re surrounded by inspiring ideas for your next lesson. A few places to look:
 
@@ -25,11 +25,11 @@ You’re surrounded by inspiring ideas for your next lesson. A few places to loo
 Plain old Googling is helpful, too. Type something like “Laravel how do I” and Google will autofill with popular search items. Lesson idea gold!
 
 
-## Be super-specific
+### Be super-specific
 
-*How do I think of good lesson ideas?* 
+*How do I think of good lesson ideas?*
 
-You just answered your own question. Use the phrase “How do I” to zero in on a specific topic to cover. 
+You just answered your own question. Use the phrase “How do I” to zero in on a specific topic to cover.
 
 *“How do I...debug angular applications with Chrome DevTools”*
 
@@ -48,9 +48,9 @@ You’ll need a few days to cover that one. Think much smaller, and dive into a 
 *“How do I create a component with React on Rails?”* That can be a lesson. In fact, it [*is*](https://egghead.io/lessons/react-creating-a-component-with-react-on-rails) [a lesson](https://egghead.io/lessons/react-creating-a-component-with-react-on-rails).
 
 
-## Write it and code it
+### Write it and code it
 
-Think you have your lesson topic? Great! Now you need to stress test your topic to see if it’s focused enough. 
+Think you have your lesson topic? Great! Now you need to stress test your topic to see if it’s focused enough.
 
 *[Image: Something like detailing a car...showing very precise work.]*
 
@@ -60,15 +60,15 @@ Create these three supporting materials:
 - [**Your lesson summary**](https://paper.dropbox.com/doc/04-Write-the-title-and-summary-iVzKqXCdSUWZbV5oKOrST). If it’s too long or requires a lot of detail to summarize, you might need to reduce the lesson’s scope.
 - [**The code example**](https://paper.dropbox.com/doc/05-Create-your-code-example-cDZZONYRKCLyHsIKaIuSY) you’ll use to demonstrate the lesson concept. It should be easy to run with very few simple steps. If it requires several steps and screens—and if you anticipate needing to give a lot of background and contextual information to explain those steps—tighten your scope.
 
-Think of these items as the outline you’d create before writing a school essay. If that outline gets too long and ambitious, you need to reel in the scope a bit. 
+Think of these items as the outline you’d create before writing a school essay. If that outline gets too long and ambitious, you need to reel in the scope a bit.
 
 
-## That lesson already exists? Do it anyway!
+### That lesson already exists? Do it anyway!
 
 We have zero qualms about repeating topics. Actually, [we encourage it](https://paper.dropbox.com/doc/03-What-if-a-lesson-already-exists-EkgS7A0FsyKtftFTs2Yr1). No one knows exactly what you know or phrases things in your particular way. What’s your take? Tell us! Tell everybody.
 
 
-## Slack us!
+### Slack us!
 
 Truly stuck? #ask us for a jumpstart, or come up with some ideas and we’ll pare them down.
 

--- a/instructor-guide/docs/02-Creating-lessons/03-What-if-a-lesson-already-exists.md
+++ b/instructor-guide/docs/02-Creating-lessons/03-What-if-a-lesson-already-exists.md
@@ -32,7 +32,3 @@ Our instructors’ diversity also reflects the learners who watch our lessons. O
 Even if you’re relatively new to a concept, your perspective is important. There’s no replacing the beginner’s mindset—when concepts are new and exciting, when you see them with fresh eyes and clarity.
 
 So even if someone more “experienced” has made a lesson about that concept, make your lesson anyway. Other beginners might learn better from you than the seasoned veteran.
-
-Next up → [Write the title and summary](https://paper.dropbox.com/doc/04-Write-the-title-and-summary-iVzKqXCdSUWZbV5oKOrST)
-
-

--- a/instructor-guide/docs/02-Creating-lessons/03-What-if-a-lesson-already-exists.md
+++ b/instructor-guide/docs/02-Creating-lessons/03-What-if-a-lesson-already-exists.md
@@ -1,5 +1,5 @@
-# 03 - What if a lesson already exists?
-Do you have a great lesson idea, but someone else got to it first? Make that lesson anyway. 
+## What if a lesson already exists?
+Do you have a great lesson idea, but someone else got to it first? Make that lesson anyway.
 
 
 > Boy, egghead.io sure has too many lessons on the fundamentals of React!
@@ -7,7 +7,7 @@ Do you have a great lesson idea, but someone else got to it first? Make that les
 This was said by nobody, ever. We firmly believe that hard topics need the fundamentals covered by good examples. A lot of them. It helps people learn!
 
 
-## Learning in layers
+### Learning in layers
 
 At egghead, we want to cover concepts in layers. We want to tuck our members in under cotton, wool, and down and help them fully and completely understand complex concepts one bite-sized lesson at a time.
 
@@ -18,20 +18,20 @@ Having one “expert” rule a concept only gives learners a one-sided, one-dime
 So what’s your take on the concept? It’s an essential layer. Add it to the mix.
 
 
-## Diversity on both sides of learning
+### Diversity on both sides of learning
 
-One of the things that makes egghead different from other learn-to-code services is how much we prioritize our instructors’ diversity. Our instructors live on six continents—Antarctica, you’re next!—and they all have different backgrounds, perspectives, and approaches to coding. That’s awesome! 
+One of the things that makes egghead different from other learn-to-code services is how much we prioritize our instructors’ diversity. Our instructors live on six continents—Antarctica, you’re next!—and they all have different backgrounds, perspectives, and approaches to coding. That’s awesome!
 
 *[Illustration: diversity on egghead]*
 
-Our instructors’ diversity also reflects the learners who watch our lessons. One instructor’s way of explaining a concept might not break through to someone, but another instructor’s might. It’s all about the code example you create, your unique turns of phrase, the you that *you* bring to it. 
+Our instructors’ diversity also reflects the learners who watch our lessons. One instructor’s way of explaining a concept might not break through to someone, but another instructor’s might. It’s all about the code example you create, your unique turns of phrase, the you that *you* bring to it.
 
 
-## Beginners are experts, too!
+### Beginners are experts, too!
 
-Even if you’re relatively new to a concept, your perspective is important. There’s no replacing the beginner’s mindset—when concepts are new and exciting, when you see them with fresh eyes and clarity. 
+Even if you’re relatively new to a concept, your perspective is important. There’s no replacing the beginner’s mindset—when concepts are new and exciting, when you see them with fresh eyes and clarity.
 
-So even if someone more “experienced” has made a lesson about that concept, make your lesson anyway. Other beginners might learn better from you than the seasoned veteran. 
+So even if someone more “experienced” has made a lesson about that concept, make your lesson anyway. Other beginners might learn better from you than the seasoned veteran.
 
 Next up → [Write the title and summary](https://paper.dropbox.com/doc/04-Write-the-title-and-summary-iVzKqXCdSUWZbV5oKOrST)
 

--- a/instructor-guide/docs/02-Creating-lessons/04-Write-the-title-and-summary.md
+++ b/instructor-guide/docs/02-Creating-lessons/04-Write-the-title-and-summary.md
@@ -62,7 +62,3 @@ So our title and summary are:
 > In this lesson, you will learn to dynamically update a React component's state based on the properties that are passed into it. We will take a look at the React component `componentWillReceiveProps` lifecycle method, and how to use it effectively.
 
 ✅✅
-
-Next up → [Create your code example](https://paper.dropbox.com/doc/05-Create-your-code-example-cDZZONYRKCLyHsIKaIuSY)
-
-

--- a/instructor-guide/docs/02-Creating-lessons/04-Write-the-title-and-summary.md
+++ b/instructor-guide/docs/02-Creating-lessons/04-Write-the-title-and-summary.md
@@ -1,10 +1,10 @@
-# 04 - Write the title and summary
-Naming things is hard. Naming things is vital. 
+## Write the title and summary
+Naming things is hard. Naming things is vital.
 
 Giving your lesson a solid title and summary *before you hit record* helps you define the scope of your lesson. With strong titles and summaries, you also make your content more useful and meaningful to the thousands of developers who will watch it.
 
 
-## Narrow your scope
+### Narrow your scope
 
 There are thousands of lessons on egghead that learners find via site and Google search. The best way for them to find your lesson is with a robust, descriptive title.
 
@@ -13,10 +13,10 @@ There are thousands of lessons on egghead that learners find via site and Google
 ![](https://media.giphy.com/media/XIqCQx02E1U9W/giphy.gif)
 
 
-Let's walk through the process of choosing your subject matter, then writing your title and summary. 
+Let's walk through the process of choosing your subject matter, then writing your title and summary.
 
 
-## Start with an idea: 
+### Start with an idea:
 
 *“I've been working with React a lot lately. Something interesting about React components and their lifecycle methods that fire at particular times?"*
 
@@ -29,10 +29,10 @@ That’s a tempting title! But it's too broad for a bite-sized lesson. Let's nar
 
 *"Reading about lifecycle methods in the React docs, I've noticed that* `*componentWillReceiveProps*` *isn't as clear as some of the others."*
 
-Now we have a target! 
+Now we have a target!
 
 
-## Summarize the concept
+### Summarize the concept
 
 Continuing to drill down on `componentWillReceiveProps`, we can write a quick summary of what the viewer can expect:
 
@@ -42,11 +42,11 @@ Continuing to drill down on `componentWillReceiveProps`, we can write a quick su
 That’s a strong, succinct concept that you can reasonably cover in a few minutes. ✅
 
 
-## Write your title (the summary of your summary)
+### Write your title (the summary of your summary)
 
 Here's a trick to coming up with a good title: Think "How do I..." and then summarize your summary.
 
-You wouldn't say "How do I... react component lifecycle methods: `componentWillReceiveProps.` ” 
+You wouldn't say "How do I... react component lifecycle methods: `componentWillReceiveProps.` ”
 
 Instead, you would say something like "How do I... use `componentWillReceiveProps` to manage react component state?”
 

--- a/instructor-guide/docs/02-Creating-lessons/05-Create-your-code-example.md
+++ b/instructor-guide/docs/02-Creating-lessons/05-Create-your-code-example.md
@@ -41,6 +41,3 @@ Embedded examples let learners play around with your code to apply what they’v
 ### Slack us!
 
 Need help with Plunker or want a second pair of eyes on your example? Share it with your coach on Slack. They’ve seen hundreds of examples—some extraordinary, some ehh—so don’t be self-conscious about your coding skills. Your coach will kindly point out anything to fix or ways to tighten your scope.
-
-Next up → [How to instruct](https://paper.dropbox.com/doc/06-How-to-instruct-z72d73FEvscPjJwwGDLIS)
-

--- a/instructor-guide/docs/02-Creating-lessons/05-Create-your-code-example.md
+++ b/instructor-guide/docs/02-Creating-lessons/05-Create-your-code-example.md
@@ -1,33 +1,33 @@
-# 05 - Create your code example
+## Create your code example
 The code example shows your concept in action. It’s the foundation of your lesson.
 
-A good example is simple and focused on one ultra-specific concept. After watching your lesson, the learner will have access to the code in Plunker to play around with, so your example should be easy to run with in just a few simple steps without in-depth knowledge of a specific domain. 
+A good example is simple and focused on one ultra-specific concept. After watching your lesson, the learner will have access to the code in Plunker to play around with, so your example should be easy to run with in just a few simple steps without in-depth knowledge of a specific domain.
 
 
-## What should your example look like?
+### What should your example look like?
 
 Your code example will almost definitely have two different states: a start and a finish.
 
 The *start* state could either be:
 
 - a blank screen, if you’re starting from scratch
-- a structured shell that you add to 
+- a structured shell that you add to
 
-The *finished* state will reflect the concept that you’ve just explained. 
+The *finished* state will reflect the concept that you’ve just explained.
 
 *[Gif: showing the transition from start to finish]*
 
 The difference between *start* and *finish* directly defines the scope and complexity of the lesson. If you can’t get to *finish* in under 10 minutes or without using complex steps, you should probably [revisit your title and summary](https://paper.dropbox.com/doc/04-Write-the-title-and-summary-iVzKqXCdSUWZbV5oKOrST) and scale back a bit. Don’t try to boil the ocean!
 
 
-## If there’s more you want to cover...
+### If there’s more you want to cover...
 
 There’s always more to learn. Always. We can’t teach it all, and we especially can’t teach everything in a single lesson.
 
 If you’re an experienced egghead instructor with a few published lessons and you want to keep expanding on your example, it might be time to [create a course](https://paper.dropbox.com/doc/01-Why-create-a-course-iZcSERF74YnnkF5oDYKrD). With courses, one example is used as a connective thread throughout several lessons. Courses are a great challenge, and they often make you more money. 💰
 
 
-## Your code embedded
+### Your code embedded
 
 Every egghead lesson page has a spot for the viewer to find the relevant code. Depending on the lesson’s context, the code may be linked to a GitHub repo/gist, or embedded from one of several popular “code playground” sites like Plunker and CodeSandbox.
 
@@ -38,7 +38,7 @@ Every egghead lesson page has a spot for the viewer to find the relevant code. D
 Embedded examples let learners play around with your code to apply what they’ve just learned. It’s a good reminder: Though your lesson may feel like a performance, it exists to help other web developers learn. For more information, check out Sharing your code.
 
 
-## Slack us!
+### Slack us!
 
 Need help with Plunker or want a second pair of eyes on your example? Share it with your coach on Slack. They’ve seen hundreds of examples—some extraordinary, some ehh—so don’t be self-conscious about your coding skills. Your coach will kindly point out anything to fix or ways to tighten your scope.
 

--- a/instructor-guide/docs/02-Creating-lessons/06-How-to-instruct.md
+++ b/instructor-guide/docs/02-Creating-lessons/06-How-to-instruct.md
@@ -31,7 +31,3 @@ Same with egghead lessons. Before you hit record, explain your code example to y
 You’ll probably trip over your words. You might realize you know how to do something but not how to *articulate* it. That’s okay—write notes to yourself and put your knowledge into words.
 
 When it’s time to record, you’ll be more than ready.
-
-Next up → [Speak concisely](https://paper.dropbox.com/doc/07-Speak-concisely-v5Rk1EjXfhwrri6cRuPGA)
-
-

--- a/instructor-guide/docs/02-Creating-lessons/06-How-to-instruct.md
+++ b/instructor-guide/docs/02-Creating-lessons/06-How-to-instruct.md
@@ -1,26 +1,26 @@
-# 06 - How to instruct
+## How to instruct
 Once you’ve nailed your title, summary, and code example, it’s time to figure out what you’re going to say.
 
-The “instructor” title can feel daunting. Don’t let it! If you’ve ever shown someone how to do something, you’re an experienced instructor. 
+The “instructor” title can feel daunting. Don’t let it! If you’ve ever shown someone how to do something, you’re an experienced instructor.
 
 
-## Speak to support the code
+### Speak to support the code
 
-In your lesson, you should show first (with your code) then maybe explain (with your voice). Your narration is quite simply the explanation of the changes you’re making to your code as you take it from its *start* state to its *finished* state. 
+In your lesson, you should show first (with your code) then maybe explain (with your voice). Your narration is quite simply the explanation of the changes you’re making to your code as you take it from its *start* state to its *finished* state.
 
 You won’t be asking questions that teachers typically do, like “What themes can we draw from this?” You will simply relay information, explain how and why you did what, and let the learners soak it in. **Keep it simple and focused on the code.**
 
 
-## Write a script or outline
+### Write a script or outline
 
 Your narration should sound casual but informed, like you’re showing something to a coworker. Some instructors find it helpful to **write out a script** beforehand so they’re never in doubt of what to say. It’s a great way to cut the “umm”s and “uhh”s and make your explanation as tight as possible.
 
 *[Illustration: bullet points on paper]*
 
-If you’d rather sound more conversational, less scripted, **write out an outline**. We’re talking bullet points—the keywords you want to say, the points you want to hit. This approach may require you to edit a few seconds of dead air here and there, but the published narration will sound polished. 
+If you’d rather sound more conversational, less scripted, **write out an outline**. We’re talking bullet points—the keywords you want to say, the points you want to hit. This approach may require you to edit a few seconds of dead air here and there, but the published narration will sound polished.
 
 
-## Do a dress rehearsal
+### Do a dress rehearsal
 
 Have you ever conducted a workshop? Talked at a conference? Presented to your sixth grade class? You know how essential it is to practice your talk before showtime.
 
@@ -32,6 +32,6 @@ You’ll probably trip over your words. You might realize you know how to do som
 
 When it’s time to record, you’ll be more than ready.
 
-Next up → [Speak concisely](https://paper.dropbox.com/doc/07-Speak-concisely-v5Rk1EjXfhwrri6cRuPGA) 
+Next up → [Speak concisely](https://paper.dropbox.com/doc/07-Speak-concisely-v5Rk1EjXfhwrri6cRuPGA)
 
 

--- a/instructor-guide/docs/02-Creating-lessons/07-Speak-concisely.md
+++ b/instructor-guide/docs/02-Creating-lessons/07-Speak-concisely.md
@@ -21,6 +21,3 @@ Note how active those sentences are: *install webpack. Run init. Open the config
 ### How much personality can we bring to our lessons?
 
 Bring all your charm and favorite idioms to your narration *as long as they support your code example*. That’s what egghead learners come to see: good code. Use the [“show your work” trick](https://paper.dropbox.com/doc/08-The-show-your-work-trick-LSi5Afd81Ougalm84MYWe) to determine if you should talk less, code more.
-
-Next up → [The “show your work” trick](https://paper.dropbox.com/doc/08-The-show-your-work-trick-LSi5Afd81Ougalm84MYWe)
-

--- a/instructor-guide/docs/02-Creating-lessons/07-Speak-concisely.md
+++ b/instructor-guide/docs/02-Creating-lessons/07-Speak-concisely.md
@@ -1,5 +1,5 @@
-# 07 - Speak concisely
-By now, you know the drill: egghead lessons are short and to the point. That goes for the videos, which should be 1–10 minutes long. It also goes for your narration. Less is more. 
+## Speak concisely
+By now, you know the drill: egghead lessons are short and to the point. That goes for the videos, which should be 1–10 minutes long. It also goes for your narration. Less is more.
 
 Consider this example:
 
@@ -18,7 +18,7 @@ Without the over-instruction, we have a much more concise, energetic start to th
 Note how active those sentences are: *install webpack. Run init. Open the config*. Those are instructions.
 
 
-## How much personality can we bring to our lessons?
+### How much personality can we bring to our lessons?
 
 Bring all your charm and favorite idioms to your narration *as long as they support your code example*. That’s what egghead learners come to see: good code. Use the [“show your work” trick](https://paper.dropbox.com/doc/08-The-show-your-work-trick-LSi5Afd81Ougalm84MYWe) to determine if you should talk less, code more.
 

--- a/instructor-guide/docs/02-Creating-lessons/08-The-show-your-work-trick.md
+++ b/instructor-guide/docs/02-Creating-lessons/08-The-show-your-work-trick.md
@@ -1,25 +1,25 @@
-# 08 - The “show your work” trick
+## The “show your work” trick
 egghead lessons are concise by definition, but there’s another reason to keep your lessons sharply defined.
 
 Too many ideas in one lesson means you’re glossing over concepts. Let’s say you mention “condition X could crash your app” because you want to cover your bases, yet you don’t take the time to really get into that subject. All you’ve accomplished is alarming your audience without giving them any solution.
 
 
-## Show, don’t tell
+### Show, don’t tell
 
-*Show your work!* You probably heard this when your high school math teacher forced you to write out the steps to a solution to get full credit for your answer. 
+*Show your work!* You probably heard this when your high school math teacher forced you to write out the steps to a solution to get full credit for your answer.
 
 *[Image: math problem supported by written steps]*
 
-It applies to coding instruction, too. The simple act of typing something out, highlighting a block with your mouse, or logging something in the console makes concepts infinitely more approachable. 
+It applies to coding instruction, too. The simple act of typing something out, highlighting a block with your mouse, or logging something in the console makes concepts infinitely more approachable.
 
-If a user sees you walk through those steps, they gain confidence that they can do it, too. If they only hear you *talking* about concepts, they can’t readily tie the concepts back to the code. Worse yet, they might stop paying attention altogether. 
+If a user sees you walk through those steps, they gain confidence that they can do it, too. If they only hear you *talking* about concepts, they can’t readily tie the concepts back to the code. Worse yet, they might stop paying attention altogether.
 
 
-## Watch on mute
+### Watch on mute
 
-Here’s the trick: Turn off your audio and watch your lesson without sound. 
+Here’s the trick: Turn off your audio and watch your lesson without sound.
 
-It should be obvious from the visuals what you’re teaching. You may notice periods of 5+ seconds where nothing is happening. “Nothing” usually means you’re getting off-topic and thought it would be tough to *show* what you’re talking about. When you catch a section of “nothing,” write down the topic you weren’t showing. Save it for another lesson! 
+It should be obvious from the visuals what you’re teaching. You may notice periods of 5+ seconds where nothing is happening. “Nothing” usually means you’re getting off-topic and thought it would be tough to *show* what you’re talking about. When you catch a section of “nothing,” write down the topic you weren’t showing. Save it for another lesson!
 
 *[ Gif: Screen with very active mouse.]*
 

--- a/instructor-guide/docs/02-Creating-lessons/08-The-show-your-work-trick.md
+++ b/instructor-guide/docs/02-Creating-lessons/08-The-show-your-work-trick.md
@@ -27,7 +27,3 @@ It should be obvious from the visuals what you’re teaching. You may notice per
 
 
 With this one trick, you’ll quickly turn one lesson with a lot of tangents into a focused, concise lesson about one topic. Or if you’re interested in creating a course, those tangents could each be a separate lesson.
-
-Next up → [Record and upload your lesson](https://paper.dropbox.com/doc/09-Record-and-upload-your-lesson-XTmUn4NSEShbJ9RQcYDgd)
-
-

--- a/instructor-guide/docs/02-Creating-lessons/09-Record-and-upload-your-lesson.md
+++ b/instructor-guide/docs/02-Creating-lessons/09-Record-and-upload-your-lesson.md
@@ -1,8 +1,8 @@
-# 09 - Record and upload your lesson
+## Record and upload your lesson
 Now that you know how to [be concise](https://paper.dropbox.com/doc/07-Speak-concisely-v5Rk1EjXfhwrri6cRuPGA), [narrate your lesson](https://paper.dropbox.com/doc/06-How-to-instruct-z72d73FEvscPjJwwGDLIS), and [show your work](https://paper.dropbox.com/doc/08-The-show-your-work-trick-LSi5Afd81Ougalm84MYWe), it’s time to record for real.
 
 
-## Recording your screencast
+### Recording your screencast
 
 We’ve put together an entire Technical Guide to help you *record* your screencasts. Find out how to:
 
@@ -14,7 +14,7 @@ We’ve put together an entire Technical Guide to help you *record* your screenc
 Okay, that handles the specifics of recording. But the word *record* is so...official. What if you mess up?
 
 
-- **Make mistakes!** Your video isn't a live presentation. Mistakes and restarts are fine. Sometimes you need to cough, kids run through, a train rolls by. Edit it out later. 
+- **Make mistakes!** Your video isn't a live presentation. Mistakes and restarts are fine. Sometimes you need to cough, kids run through, a train rolls by. Edit it out later.
 
 
 ![](https://media1.giphy.com/media/3oKIPoAP1wLvewc7QI/giphy.gif)
@@ -27,7 +27,7 @@ Okay, that handles the specifics of recording. But the word *record* is so...off
 If you want a second pair of eyes before uploading your lesson, reach out to your coach on Slack. Or go ahead and upload, and you’ll get feedback after that. Remember, we’re here to support you and help you succeed!
 
 
-## Upload your lesson
+### Upload your lesson
 
 When your draft is complete, upload it to [egghead.io](https://egghead.io/). When you upload any lesson video, it’s automatically processed to make sure its audio is in stereo, the resolution is as expected, and that it’s uploaded to the appropriate storage channels.
 
@@ -40,11 +40,11 @@ Feedback in hand, you’ll be able to edit and update your video. When your coac
 Sometimes this can take a few minutes. If an hour goes by and your lesson video still isn’t visible, let us know!
 
 
-## Lesson review and approval
+### Lesson review and approval
 
 Once you complete all the above steps, your lesson will be reviewed for approval. Reviewing means an experienced egghead instructor—someone other than your coach—will watch your lesson and provide feedback. It’s not uncommon that your lesson will require a couple of updates. Just record the required changes and replace the lesson’s video on egghead.
 
-Then we publish! 🍾 
+Then we publish! 🍾
 
 Next up → [When we’ll publish your lesson](https://paper.dropbox.com/doc/10-When-well-publish-your-lesson-qdibFLmE1mZVc976Cbs5n)
 

--- a/instructor-guide/docs/02-Creating-lessons/09-Record-and-upload-your-lesson.md
+++ b/instructor-guide/docs/02-Creating-lessons/09-Record-and-upload-your-lesson.md
@@ -45,6 +45,3 @@ Sometimes this can take a few minutes. If an hour goes by and your lesson video 
 Once you complete all the above steps, your lesson will be reviewed for approval. Reviewing means an experienced egghead instructor—someone other than your coach—will watch your lesson and provide feedback. It’s not uncommon that your lesson will require a couple of updates. Just record the required changes and replace the lesson’s video on egghead.
 
 Then we publish! 🍾
-
-Next up → [When we’ll publish your lesson](https://paper.dropbox.com/doc/10-When-well-publish-your-lesson-qdibFLmE1mZVc976Cbs5n)
-

--- a/instructor-guide/docs/02-Creating-lessons/10-When-well-publish-your-lesson.md
+++ b/instructor-guide/docs/02-Creating-lessons/10-When-well-publish-your-lesson.md
@@ -34,7 +34,3 @@ After publishing, lessons are added to egghead’s social media sharing queue. T
 You did it. You’re a published instructor.
 
 Ready to do it all again?
-
-Next chapter → [Creating Courses](https://paper.dropbox.com/folder/show/03-Creating-Courses-e.1gg8YzoPEhbTkrhvQwJ2zz3VfffmUAdE5S3JSeZuhI7wEA2BNaqR)
-Next up -> [Why create a course](https://paper.dropbox.com/doc/01-Why-create-a-course-iZcSERF74YnnkF5oDYKrD)
-

--- a/instructor-guide/docs/02-Creating-lessons/10-When-well-publish-your-lesson.md
+++ b/instructor-guide/docs/02-Creating-lessons/10-When-well-publish-your-lesson.md
@@ -1,37 +1,37 @@
-# 10 - When we’ll publish your lesson
+## When we’ll publish your lesson
 You’ve made it to the finish line. Hooray!
 
-Once you’ve uploaded your lesson and gotten the official thumbs up, your lesson enters egghead’s lesson publishing queue. 
+Once you’ve uploaded your lesson and gotten the official thumbs up, your lesson enters egghead’s lesson publishing queue.
 
 *[ Image: publishing queue ]*
 
-The queue automatically publishes lessons from top to bottom. We publish several times per week and sometimes daily, depending on how many lessons are in the queue. This way, we make sure we’re keeping our subscribers happy with a steady stream of great content. 
+The queue automatically publishes lessons from top to bottom. We publish several times per week and sometimes daily, depending on how many lessons are in the queue. This way, we make sure we’re keeping our subscribers happy with a steady stream of great content.
 
 
-## New instructors 
+### New instructors
 
 Lucky you—we move new instructors’ lessons to the top of the queue. This gives you a quick win after going through the process of recording your 30-second sample, making edits, recording your lesson for real, making *more* edits, and finally getting that coveted approval.
 
 You’ve come a long way. Celebrate!
 
 
-## Experienced instructors 
+### Experienced instructors
 
 When an instructor has 12 published lessons, they gain the ability to review, approve, and publish their own content! Hot damn!
 
 We trust you to make sure the quality of your lesson is high. You can still ask for review if you want it, or you can simply add your lesson to the publishing queue by approving it like a baller.
 
 
-## Sharing your lesson on social media
+### Sharing your lesson on social media
 
 After publishing, lessons are added to egghead’s social media sharing queue. This drives a lot of eyeballs to our lessons—our Twitter account has over 45,000 followers.
 
 *[ Image: tweet announcing a new lesson ]*
 
 
-## That’s it!
+### That’s it!
 
-You did it. You’re a published instructor. 
+You did it. You’re a published instructor.
 
 Ready to do it all again?
 

--- a/instructor-guide/docs/03-Creating-Courses/01-Why-create-a-course.md
+++ b/instructor-guide/docs/03-Creating-Courses/01-Why-create-a-course.md
@@ -1,5 +1,5 @@
-# 01 - Why create a course
-Courses are the bread and butter of egghead. 
+## Why create a course
+Courses are the bread and butter of egghead.
 
 A course is a composed set of bite-sized lessons. The course itself should be bite-sized, covering a single topic in depth through a sequence of individual lessons.
 
@@ -21,7 +21,7 @@ If that sounds like a lot of work, that’s because it *is*. Each lesson takes a
 But the payoff is worth it. Why?
 
 
-## egghead members love them
+### egghead members love them
 
 Humans love curated knowledge. They want to learn a topic in depth, but at a pace that works for them.
 
@@ -32,18 +32,18 @@ egghead courses give hungry learners a sequence to follow, with the promise of g
 Which brings us to our next point...
 
 
-## You make more money!
+### You make more money!
 
 No two ways about it, courses get more eyeballs than individual lessons. It just makes sense: When you publish courses, you publish several lessons at a time. That’s more content and more chances for views.
 
 *[Illustration: $$$$]*
 
-Not only that: Learners often watch those lessons consecutively. (Obviously. That’s what a course is meant for.) 
+Not only that: Learners often watch those lessons consecutively. (Obviously. That’s what a course is meant for.)
 
 Once your course is published, it can continue to create a passive revenue stream for you. Learners will keep watching, and the royalties will keep coming in.
 
 
-## You want to do more with your code
+### You want to do more with your code
 
 When you’re going through the process of crafting a lesson—creating your [code example](https://paper.dropbox.com/doc/05-Create-your-code-example-cDZZONYRKCLyHsIKaIuSY) and using the [“show your work” trick](https://paper.dropbox.com/doc/08-The-show-your-work-trick-LSi5Afd81Ougalm84MYWe)—you might need to cut out some cool information. Either because it’s off-topic, or because it widens the scope of your lesson way beyond 10 minutes.
 

--- a/instructor-guide/docs/03-Creating-Courses/01-Why-create-a-course.md
+++ b/instructor-guide/docs/03-Creating-Courses/01-Why-create-a-course.md
@@ -50,7 +50,3 @@ When you’re going through the process of crafting a lesson—creating your [co
 Never fear, courses are here.
 
 Turn that excess info into a string of lessons, and you’ll have yourself a course. A course will take one code example and use a few different diffs to show different concepts. If you’re feeling hamstrung by the bite-sized nature of individual lessons, courses give you a little more room to play and showcase what you know.
-
-Next up → [How to structure your course](https://paper.dropbox.com/doc/02-How-to-structure-your-course-YfYDW8HSjx7DsAEShXc4X)
-
-

--- a/instructor-guide/docs/03-Creating-Courses/02-How-to-structure-your-course.md
+++ b/instructor-guide/docs/03-Creating-Courses/02-How-to-structure-your-course.md
@@ -1,43 +1,43 @@
-# 02 - How to structure your course
+## How to structure your course
 *Illustration note: I’m at a loss for how to explain these concepts visually.* @Maggie A *, any ideas?*
 
-There are several types of egghead courses. The most important aspects of a course are tight focus and high-quality examples. If you have those two things, the style doesn't matter. 
+There are several types of egghead courses. The most important aspects of a course are tight focus and high-quality examples. If you have those two things, the style doesn't matter.
 
 But it always helps to have a plan, and you might benefit from having a set format to guide you. These course types are excellent places to start.
 
 
-## Documentation 
+### Documentation
 
 *[Illustration: a piece of paper?]*
 
-This type of course is a straightforward presentation of the documentation for a library, framework, or tool. Dan Abramov's [popular course on Redux](https://egghead.io/courses/getting-started-with-redux) is a great example. 
+This type of course is a straightforward presentation of the documentation for a library, framework, or tool. Dan Abramov's [popular course on Redux](https://egghead.io/courses/getting-started-with-redux) is a great example.
 
-A documentation presentation doesn't mean you simply read the docs to the student. Instead, take the docs and present them with high-quality examples. 
+A documentation presentation doesn't mean you simply read the docs to the student. Instead, take the docs and present them with high-quality examples.
 
 
-## Project-based
+### Project-based
 
 *[project-based illustration]*
 
-Another favorite is a project-based approach. In this case, the course amounts to a project that the student will build from start to finish. 
+Another favorite is a project-based approach. In this case, the course amounts to a project that the student will build from start to finish.
 
 Our cofounder John Lindquist did this with his [Build Redux Style Applications course](https://egghead.io/courses/build-redux-style-applications-with-angular-rxjs-and-ngrx-store), using Angular, RxJS, and ngrx/store as its bases.
 
 
-## Cookbook
+### Cookbook
 
-*[cookbook illustration]* 
+*[cookbook illustration]*
 
-You can also present a series of problems and solutions in the "cookbook" style. A typical recipe will include some common (or maybe not-so-common) problems, and then provide an example solution for the problem using the tool the cookbook is discussing. 
+You can also present a series of problems and solutions in the "cookbook" style. A typical recipe will include some common (or maybe not-so-common) problems, and then provide an example solution for the problem using the tool the cookbook is discussing.
 
 Trevor D. Miller's [React Testing Cookbook](https://egghead.io/courses/react-testing-cookbook) course is a solid example of this approach.
 
 
-## You decide!
+### You decide!
 
 *[Illustration: brainstorming]*
 
-You're smart and creative, and definitely not limited to any of these course types. If you've got an idea for a new way to structure your course, let's hear it! 
+You're smart and creative, and definitely not limited to any of these course types. If you've got an idea for a new way to structure your course, let's hear it!
 
 Next up → [Write your course proposal](https://paper.dropbox.com/doc/03-Write-your-course-proposal-FEMzHM8qNiv4BdZiDhJvO)
 

--- a/instructor-guide/docs/03-Creating-Courses/02-How-to-structure-your-course.md
+++ b/instructor-guide/docs/03-Creating-Courses/02-How-to-structure-your-course.md
@@ -38,7 +38,3 @@ Trevor D. Miller's [React Testing Cookbook](https://egghead.io/courses/react-tes
 *[Illustration: brainstorming]*
 
 You're smart and creative, and definitely not limited to any of these course types. If you've got an idea for a new way to structure your course, let's hear it!
-
-Next up → [Write your course proposal](https://paper.dropbox.com/doc/03-Write-your-course-proposal-FEMzHM8qNiv4BdZiDhJvO)
-
-

--- a/instructor-guide/docs/03-Creating-Courses/03-Write-your-course-proposal.md
+++ b/instructor-guide/docs/03-Creating-Courses/03-Write-your-course-proposal.md
@@ -1,4 +1,4 @@
-# 03 - Write your course proposal
+## Write your course proposal
 
 *[This article doesn’t lend itself to much illustration.* @Maggie A *, do you have any ideas?]*
 
@@ -6,10 +6,10 @@ Before you start producing your egghead course, we ask you to write and submit a
 
 For you, the proposal defines your intent for the course, and gives you a chance to craft great titles for the course and its lessons to guide your work.
 
-For us at egghead, your proposal lets us think more deeply about the content and structure of the course to make sure it’s solidly planned and delivers a ton of value to your learners. 
+For us at egghead, your proposal lets us think more deeply about the content and structure of the course to make sure it’s solidly planned and delivers a ton of value to your learners.
 
 
-## How to structure your proposal
+### How to structure your proposal
 
 Here’s a perfect [example of a course proposal](https://docs.google.com/document/d/1goXtI_zmSfXTgaimrxIss356DoedPRt5MMAySs1f-bE/edit), and here's [a blank template](https://docs.google.com/document/d/1x5_UehD9mM2jeCtlqEZFy3epDLLmbgBBGCow5fDRNCc/edit#) for you to use.
 
@@ -25,7 +25,7 @@ The proposal should consist of 4 parts:
 Let’s look at each of these in more detail.
 
 
-## The user story
+### The user story
 
 Your course proposal starts with a *user story*. This is similar to the agile software practice of writing a story to describe **who**, **what**, and **why** we’re creating this thing.
 
@@ -39,30 +39,30 @@ For example:
 This short exercise helps you think like your learners to define what challenge(s) your course will help them solve.
 
 
-## Goals
+### Goals
 
-The second section of your proposal lists your goals for the course. 
+The second section of your proposal lists your goals for the course.
 
-- What am I trying to teach? 
-- Why am I teaching it? 
+- What am I trying to teach?
+- Why am I teaching it?
 - What knowledge should the learner walk away with?
 
 
-## Summary
+### Summary
 
-The course summary is one paragraph (or two short paragraphs) that describes the course, the technology you’ll cover, and what will be learned. 
+The course summary is one paragraph (or two short paragraphs) that describes the course, the technology you’ll cover, and what will be learned.
 
 Here’s the summary from the [example we shared](https://docs.google.com/document/d/1goXtI_zmSfXTgaimrxIss356DoedPRt5MMAySs1f-bE/edit#):
 
 
-> In this course we will build an image gallery application that connects to the Flickr API to load its data. We are going to start from an empty directory, and build the application incrementally, discussing the problems that we might encounter along the way. The image gallery is a simple application, but even the simplest applications need to deal with application state. We will use Redux to help us with that aspect of the image gallery. For asynchronous communication, we will learn about redux-saga, a wonderful library that uses JavaScript generator functions to make complex async application “side effects” a pleasure to construct. 
+> In this course we will build an image gallery application that connects to the Flickr API to load its data. We are going to start from an empty directory, and build the application incrementally, discussing the problems that we might encounter along the way. The image gallery is a simple application, but even the simplest applications need to deal with application state. We will use Redux to help us with that aspect of the image gallery. For asynchronous communication, we will learn about redux-saga, a wonderful library that uses JavaScript generator functions to make complex async application “side effects” a pleasure to construct.
 
 Keep in mind that your approved summary will be presented along with the course on egghead.io, so only include content in your proposal that you’d want to publish. [These guidelines](https://paper.dropbox.com/doc/04-Write-the-title-and-summary-iVzKqXCdSUWZbV5oKOrST) will help you write a succinct and successful summary.
 
 
-## List of lessons
+### List of lessons
 
-Finally, the course lists each lesson in the course, including the titles and summaries for each lesson. 
+Finally, the course lists each lesson in the course, including the titles and summaries for each lesson.
 
 There’s [an art to writing a lesson title](https://paper.dropbox.com/doc/04-Write-the-title-and-summary-iVzKqXCdSUWZbV5oKOrST). By now, instructors should know how to write them. For a refresher, they should be concise and follow the "how do I..." format. The [lesson summary](https://paper.dropbox.com/doc/04-Write-the-title-and-summary-iVzKqXCdSUWZbV5oKOrST) should be just that: a summary of the technology covered and the goals for the lesson.
 
@@ -72,9 +72,9 @@ For example:
 > **Load data with redux-saga effects from an API in React** – redux-saga makes loading data from a remote API in a Redux-enabled React application very simple. In this lesson, we will create a saga that connects to the Flickr API and loads data for an image gallery component.
 
 
-## Sharing your proposal
+### Sharing your proposal
 
-Your coach will, first of all, be psyched that you’re ready to take the plunge into courses. Share your proposal with then on Slack. Did we mention that Google Docs is the way to go? 
+Your coach will, first of all, be psyched that you’re ready to take the plunge into courses. Share your proposal with then on Slack. Did we mention that Google Docs is the way to go?
 
 Now hop to it.
 

--- a/instructor-guide/docs/03-Creating-Courses/03-Write-your-course-proposal.md
+++ b/instructor-guide/docs/03-Creating-Courses/03-Write-your-course-proposal.md
@@ -77,6 +77,3 @@ For example:
 Your coach will, first of all, be psyched that you’re ready to take the plunge into courses. Share your proposal with then on Slack. Did we mention that Google Docs is the way to go?
 
 Now hop to it.
-
-Next up → [Your course code example](https://paper.dropbox.com/doc/04-Your-course-code-example-YOZpqOm2L1SYX4C0Wk2ng)
-

--- a/instructor-guide/docs/03-Creating-Courses/04-Your-course-code-example.md
+++ b/instructor-guide/docs/03-Creating-Courses/04-Your-course-code-example.md
@@ -1,12 +1,12 @@
-# 04 - **Your course code example**
+## Your course code example
 A course typically has one code example that acts as a connecting thread through the course. You’ll build on it from lesson to lesson.
 
 As soon as your course proposal is approved, you should start building your code example [in a tool like Plunker](https://paper.dropbox.com/doc/05-Sharing-your-code-XPt8sCs1hyoeAEuyK8aQr). The best format of your code example will depend on [the style of your course](https://paper.dropbox.com/doc/02-How-to-structure-your-course-YfYDW8HSjx7DsAEShXc4X). As always, #ask your coach for guidance and a second pair of eyes as you build.
 
-*[Gif: code being built]* 
+*[Gif: code being built]*
 
 
-## Sharing your code
+### Sharing your code
 
 For each lesson in a course, you’ll provide your code example in its finished state below the video so learners can explore the code on their own.
 

--- a/instructor-guide/docs/03-Creating-Courses/04-Your-course-code-example.md
+++ b/instructor-guide/docs/03-Creating-Courses/04-Your-course-code-example.md
@@ -11,6 +11,3 @@ As soon as your course proposal is approved, you should start building your code
 For each lesson in a course, you’ll provide your code example in its finished state below the video so learners can explore the code on their own.
 
 [Plunker](https://next.plnkr.co/) is our favorite tool for [creating and delivering our examples](https://paper.dropbox.com/doc/05-Sharing-your-code-XPt8sCs1hyoeAEuyK8aQr#q=how%20to%20structure). We also enjoy [CodeSandbox](https://codesandbox.io/). If they won’t work for the code you’re building, you can use a GitHub repository to store the code example. GitHub repo examples will provide a branch for each lesson, where the branch is the *finished* state of the given lesson. If your course is the ["cookbook" style](https://paper.dropbox.com/doc/02-How-to-structure-your-course-YfYDW8HSjx7DsAEShXc4X) and uses GitHub, you can just have folders in a single repo for each example.
-
-Next up → [Record your course](https://paper.dropbox.com/doc/05-Record-your-course-2Ftfxq4BN5LQDzQdwfIkA)
-

--- a/instructor-guide/docs/03-Creating-Courses/05-Record-your-course.md
+++ b/instructor-guide/docs/03-Creating-Courses/05-Record-your-course.md
@@ -10,7 +10,3 @@ When you’re ready, record your lessons and upload them one by one as they’re
 *[Screenshot: Upload button?]*
 
 And you know what? That’s all recording a course is: recording individual lessons that the egghead team will bundle together on egghead.io. By now, you’re an expert lesson-creator, but feel free to read our [guidelines to recording lessons](https://paper.dropbox.com/doc/03-Record-your-lesson-5sBpHCVOxhPhlZYEVxrhY) should you need a refresher.
-
-Next up → [Create your course overview](https://paper.dropbox.com/doc/06-Create-your-course-overview-o8gtQUwo2zTJlkiAF7VCf)
-
-

--- a/instructor-guide/docs/03-Creating-Courses/05-Record-your-course.md
+++ b/instructor-guide/docs/03-Creating-Courses/05-Record-your-course.md
@@ -1,7 +1,7 @@
-# 05 - Record your course
+## Record your course
 With all the prep you've already done for your course, a lot of the hard work is behind you.
 
-Once your proposal has been reviewed and approved, you can spend some time **iterating your lesson plans on paper** and building a solid curriculum that will be useful for thousands of developers for years to come! 
+Once your proposal has been reviewed and approved, you can spend some time **iterating your lesson plans on paper** and building a solid curriculum that will be useful for thousands of developers for years to come!
 
 *[Illustration: putting pen to paper]*
 

--- a/instructor-guide/docs/03-Creating-Courses/06-Create-your-course-overview.md
+++ b/instructor-guide/docs/03-Creating-Courses/06-Create-your-course-overview.md
@@ -20,7 +20,3 @@ Here’s what Kent did so well:
 Creating your course overview is the perfect way to conclude your production of the course. You get to stitch together “best-of” clips showing your instruction skills at work, act as your course’s hype person, and publish a publicly accessible video (all course overviews are public) that will look great in your portfolio.
 
 Oh and, hey! Congratulations on publishing your first course! 🍾
-
-Next up → [Maintain your course](https://paper.dropbox.com/doc/07-Maintain-your-course-7oO7XDq0K98juSMTeGCoL)
-
-

--- a/instructor-guide/docs/03-Creating-Courses/06-Create-your-course-overview.md
+++ b/instructor-guide/docs/03-Creating-Courses/06-Create-your-course-overview.md
@@ -1,4 +1,4 @@
-# 06 - Create your course overview
+## Create your course overview
 When your course is "lesson complete," it's time to record a course overview. Guess what: It’s another lesson! But a lesson that serves as the trailer for your course.
 
 Here’s a great example of an overview, from the course [Advanced React Component Patterns](https://egghead.io/courses/advanced-react-component-patterns) by Kent C. Dodds:

--- a/instructor-guide/docs/03-Creating-Courses/07-Maintain-your-course.md
+++ b/instructor-guide/docs/03-Creating-Courses/07-Maintain-your-course.md
@@ -1,14 +1,14 @@
-# 07 - Maintain your course
+## Maintain your course
 Ever heard of "JavaScript fatigue"? 😫
 
 Well, it affects egghead.io courses. Video is a tough format, and because libraries move at a brisk pace and forward progress is always happening—which is great!—egghead content producers have some specific challenges in keeping courses current and usable.
 
 
-## Updates from our review team
+### Updates from our review team
 
-Our egghead content team works hard to keep your course as viable as possible, as long as possible. Every day, they review courses on egghead.io to confirm the code and examples are relevant and still work. 
+Our egghead content team works hard to keep your course as viable as possible, as long as possible. Every day, they review courses on egghead.io to confirm the code and examples are relevant and still work.
 
-[ Illustration: QAing—something like this, but more fun ] 
+[ Illustration: QAing—something like this, but more fun ]
 
 ![](https://lh5.googleusercontent.com/DOu4jQBDloo8qDy6C7GnImChI7LBJQSZ88KsSDhK-BGBMcO98SP3Df86Jp0dYvOiM2_rsy6nju8wvaI8_gH3Uj3OdOUuouAf_qw6F4Yw1gjSqSwLIcejTnAsY-mA6Ch6C5oPGnOC)
 
@@ -16,11 +16,11 @@ Our egghead content team works hard to keep your course as viable as possible, a
 Same with our lessons. The content team reviews lessons to confirm they still function with the latest versions of the tools they cover. When updates are needed, our team updates the code and attaches version labels to help students understand the differences between the lesson video and the code.
 
 
-## When it’s time for big changes
+### When it’s time for big changes
 
 Time marches on. Libraries and frameworks get updated. Sometimes, that means courses become outdated or irrelevant. (This is why we created egghead in the first place—to help developers learn quickly because things change *all the time*.)
 
-If this is the case for your course, the content team will notify you so you can update the lessons on your end. That is, if you want to. But we must say, it's definitely in your best interest to keep your course updated, especially right when progress happens. There’s no better time to stake your claim to knowledge. Relevance pays off. 💰 
+If this is the case for your course, the content team will notify you so you can update the lessons on your end. That is, if you want to. But we must say, it's definitely in your best interest to keep your course updated, especially right when progress happens. There’s no better time to stake your claim to knowledge. Relevance pays off. 💰
 
 Next chapter → [Screencasting tips](https://paper.dropbox.com/folder/show/04-Screencasting-tips-e.1gg8YzoPEhbTkrhvQwJ2zz3VfffmW8lGwgJoc5jCIvamKrIozeHB)
 Next up → [Prepare your screen for recording](https://paper.dropbox.com/doc/01-Prepare-your-screen-for-recording-ead8DoI0Psy8Oz0wYQGlG)

--- a/instructor-guide/docs/03-Creating-Courses/07-Maintain-your-course.md
+++ b/instructor-guide/docs/03-Creating-Courses/07-Maintain-your-course.md
@@ -21,7 +21,3 @@ Same with our lessons. The content team reviews lessons to confirm they still fu
 Time marches on. Libraries and frameworks get updated. Sometimes, that means courses become outdated or irrelevant. (This is why we created egghead in the first place—to help developers learn quickly because things change *all the time*.)
 
 If this is the case for your course, the content team will notify you so you can update the lessons on your end. That is, if you want to. But we must say, it's definitely in your best interest to keep your course updated, especially right when progress happens. There’s no better time to stake your claim to knowledge. Relevance pays off. 💰
-
-Next chapter → [Screencasting tips](https://paper.dropbox.com/folder/show/04-Screencasting-tips-e.1gg8YzoPEhbTkrhvQwJ2zz3VfffmW8lGwgJoc5jCIvamKrIozeHB)
-Next up → [Prepare your screen for recording](https://paper.dropbox.com/doc/01-Prepare-your-screen-for-recording-ead8DoI0Psy8Oz0wYQGlG)
-

--- a/instructor-guide/docs/04-Screencasting-tips/01-Prepare-your-screen-for-recording.md
+++ b/instructor-guide/docs/04-Screencasting-tips/01-Prepare-your-screen-for-recording.md
@@ -86,5 +86,3 @@ Note: If you’re on Mac and using Bash, you also need to add a `~/.bash_profile
 This tells Mac to load your `~/.bashrc` when loading a terminal emulator.
 
 Now that your screen is ready to record, sound up. Time to get your audio ready.
-
-Next up → [Set up your audio](https://paper.dropbox.com/doc/02-Set-up-your-audio-oyhAegdRyTG7R1IkdNajZ)

--- a/instructor-guide/docs/04-Screencasting-tips/01-Prepare-your-screen-for-recording.md
+++ b/instructor-guide/docs/04-Screencasting-tips/01-Prepare-your-screen-for-recording.md
@@ -1,4 +1,4 @@
-# 01 - Prepare your screen for recording
+## Prepare your screen for recording
 
 **Success on egghead comes down to mechanics**. This guide will help you nail the technical aspects of presentation and accessibility, so you can present lessons that are visually clear and accessible for all learners and devices.
 
@@ -8,7 +8,7 @@ Screencasting isn’t easy. It’s a difficult skill to nail—and on top of tha
 
 **Always remember accessibility.** A wide range of people will access your lessons on a variety of devices of varying quality. Maximizing the legibility of the code you present helps all learners absorb the information to the best of their abilities.
 
-## Set your settings
+### Set your settings
 
 Before you do anything else, adopt these settings:
 
@@ -25,7 +25,7 @@ HiDPI mode—also known broadly as DPI scaling, or Retina display on Macs—doub
 
 ![Image courtesy of designmodo.com](https://lh3.googleusercontent.com/rMZ4R1qkndexRllRnPZxX1LwwlXyQ-pEd9FzJFqOLuyg-ly7ciad5X57pRjji2GhYL9CBaEpfocx3u0OQoC_2-tj1HqixMVmu3SGk0hKtp7ZCwn351_c9M4UXLXs7ECdzfLSb-K4)
 
-## DPI scaling on Windows
+### DPI scaling on Windows
 
 On Windows, we've had success boosting the code fonts to max out the screen. Aspect ratio is key here, so set your screen to the highest 16x9 resolution and kick the fonts up.
 
@@ -33,7 +33,7 @@ Using DPI scaling features is helpful—you can scale the OS chrome and make UI 
 
 [This article](http://www.eizoglobal.com/support/compatibility/dpi_scaling_settings_windows/) can tell you more about pixel scaling on Windows.
 
-## Access HiDPI mode on macOS
+### Access HiDPI mode on macOS
 
 On Mac, you’ll get the best results if you record at **1280x720(HiDPI) mode**. This resolution is achievable on 27" monitors and Retina MBPs. It effectively gives you a visible resolution of 1280x720, but it’s extremely crisp and readable on phones and tablets.
 
@@ -45,7 +45,7 @@ Another application that works well is [**SwitchRezX**](http://www.madrau.com/).
 
 By constraining to this small window, you can fill the screen effectively for coding screencasts. The most import thing to get correct is the aspect ratio. We don't want to present with any black bars around the screen. We want to give the user maximum code visibility at all times.
 
-## Screen and code layout
+### Screen and code layout
 
 The code is the champion of an egghead.io screencast, so it must be comfortably readable for all learners.
 
@@ -67,7 +67,7 @@ In some cases, the example is replaced by a terminal, or a terminal window share
 
 Remember that your lesson viewers are here to see the code. Make it the starring feature!
 
-## Command line prompt
+### Command line prompt
 
 If you will be showing your command line, we suggest using a minimal prompt to reduce distractions. This example prompt works well for screencasting:
 

--- a/instructor-guide/docs/04-Screencasting-tips/02-Set-up-your-audio.md
+++ b/instructor-guide/docs/04-Screencasting-tips/02-Set-up-your-audio.md
@@ -1,4 +1,4 @@
-# 02 - Set up your audio
+## Set up your audio
 Good audio starts with quality gear. Your laptop’s built-in microphone sounds decent, but we want you to sound way better than decent.
 
 When you become an egghead instructor, we hook you up! As soon as you have a draft lesson almost ready to publish, we’ll send you a waterproof Pelican case full of professional-grade audio recording equipment. 📬
@@ -19,14 +19,14 @@ Here’s what you’ll be getting:
 Let’s go through each piece of equipment and explain how you’ll use it.
 
 
-## Microphone boom
+### Microphone boom
 
 *[Image: Microphone boom]*
 
-The boom is a stand for your mic. Booms can range in size and shape. (Action movies require bigger booms than egghead lessons.) This is a very nice, sturdy boom from Germany that folds down for easy storage in the case. 
+The boom is a stand for your mic. Booms can range in size and shape. (Action movies require bigger booms than egghead lessons.) This is a very nice, sturdy boom from Germany that folds down for easy storage in the case.
 
 
-## The microphone
+### The microphone
 
 *[Image: Microphone]*
 
@@ -41,14 +41,14 @@ Positioning of the mic is important. You should be 2–6 inches away for optimal
 (We don’t really give out extra credit, but you might sound *slightly* better.)
 
 
-## Shock mount (right)
+### Shock mount (right)
 
 *[Image: Shock mount + USB audio interface]*
 
 This little piece connects to the boom, and the microphone slides into it before being attached to the XLR cable. It will dampen any footsteps or other vibrations that might be picked up through the stand to the mic. (You’ll most likely be sitting down, but who knows what your kids or roommates are up to.)
 
 
-## USB audio interface (left)
+### USB audio interface (left)
 
 The mic we’re giving you is built for professional audio applications, not necessarily for capturing audio on a computer. This interface connects the mic to your computer, and converts XLR analog signal into 1s and 0s for the computer to store. It has an XLR input (from the mic) and a USB output (to the computer).
 
@@ -57,7 +57,7 @@ Note:
 ⚡️ Turn the gain up!
 
 
-## XLR cable
+### XLR cable
 
 XLR is a plug used in professional audio applications. It isn't completely necessary since the pre-amp will plug directly into the microphone, but play around and see if it makes your sound more stable.
 
@@ -68,7 +68,7 @@ Your final setup should look something like this:
 *[Image: Finished product]*
 
 
-## Check audio input levels
+### Check audio input levels
 
 Once your gear is set up, you'll need to check the audio input levels to make sure your gain is set properly. [Here’s a lesson to help you](https://egghead.io/lessons/tools-prepare-to-record-screen-resolution-and-mic-check?play=true)
 

--- a/instructor-guide/docs/04-Screencasting-tips/02-Set-up-your-audio.md
+++ b/instructor-guide/docs/04-Screencasting-tips/02-Set-up-your-audio.md
@@ -73,6 +73,3 @@ Your final setup should look something like this:
 Once your gear is set up, you'll need to check the audio input levels to make sure your gain is set properly. [Here’s a lesson to help you](https://egghead.io/lessons/tools-prepare-to-record-screen-resolution-and-mic-check?play=true)
 
 Ta-da! You’re ready to record.
-
-Next up → [Record your lesson](https://paper.dropbox.com/doc/03-Record-your-lesson-5sBpHCVOxhPhlZYEVxrhY)
-

--- a/instructor-guide/docs/04-Screencasting-tips/03-Record-your-lesson.md
+++ b/instructor-guide/docs/04-Screencasting-tips/03-Record-your-lesson.md
@@ -1,12 +1,12 @@
-# 03 - Record your lesson
-Screencasting is one of those iceberg-like tasks: 90% of the work is behind the scenes. Only 10% is visible. 
+## Record your lesson
+Screencasting is one of those iceberg-like tasks: 90% of the work is behind the scenes. Only 10% is visible.
 
 *[Illustration: Lesson scope, code example, etc. 90%, recording 10%]*
 
 Recording your screencast is that 10%. You’ve put tons of thought and time into your lesson scope, code example, and points you want to cover. What distinguishes your success in this final stage is high-quality technical tools. (And careful editing—that’s next.)
 
 
-## Video capture
+### Video capture
 
 egghead.io instructors are provided with whatever software licenses you need. Just #ask!
 
@@ -19,7 +19,7 @@ https://www.youtube.com/watch?v=3nlJ_wP9dPE&&index=5&list=PL219naRJXQKbQJ60WxsuG
 
 
 
-## Capturing audio
+### Capturing audio
 
 There are three ways to record your screencasts. Each is completely 👌
 
@@ -36,11 +36,11 @@ There are three ways to record your screencasts. Each is completely 👌
 
 For more on audio, see our guide to [audio setup](https://paper.dropbox.com/doc/02-Set-up-your-audio-oyhAegdRyTG7R1IkdNajZ).
 
-## Record one thought at a time
+### Record one thought at a time
 
-While you’re recording, do your editing-self a favor: Record in short, high-quality chunks, one thought at a time. 
+While you’re recording, do your editing-self a favor: Record in short, high-quality chunks, one thought at a time.
 
-Think of your lesson as a series of paragraphs that take 20 seconds to record. **Between each, take a pause**. Doing this will help you avoid intense editing to move audio and video snippets around as you build your quilt-like final product. 
+Think of your lesson as a series of paragraphs that take 20 seconds to record. **Between each, take a pause**. Doing this will help you avoid intense editing to move audio and video snippets around as you build your quilt-like final product.
 
 ![](https://media.giphy.com/media/GJycRLp6zYGFq/giphy.gif)
 

--- a/instructor-guide/docs/04-Screencasting-tips/03-Record-your-lesson.md
+++ b/instructor-guide/docs/04-Screencasting-tips/03-Record-your-lesson.md
@@ -52,8 +52,3 @@ Need an example? Watch John Lindquist show how to record one thought at a time.
 **John Lindquist - Record One Thought at a Time**
 
 https://www.dropbox.com/s/cyy9swbl3ga38kd/egghead-record-one-thought-at-a-time.mp4?dl=0
-
-
-
-Next up → [Edit your lesson](https://paper.dropbox.com/doc/04-Edit-your-lesson-MeWShbq74RFNerLauz5AH)
-

--- a/instructor-guide/docs/04-Screencasting-tips/04-Edit-your-lesson.md
+++ b/instructor-guide/docs/04-Screencasting-tips/04-Edit-your-lesson.md
@@ -1,10 +1,10 @@
-# 04 - Edit your lesson
+## Edit your lesson
 Editing is your lesson’s critical last stop between you and your audience. It’s your quality filter.
 
 
-## Ripple delete
+### Ripple delete
 
-⚡️Ripple delete is your greatest ally. ⚡️ It’s basically deleting the bad parts, a chunk of seconds at a time—like that tangent you go on, that five-second period where you stammer over a word, and those dozens of “umm”s and “like”s you had no idea you said so often. Ripple delete couldn’t be easier or more essential, and it’s available in both Camtasia and Screenflow. 🙌 
+⚡️Ripple delete is your greatest ally. ⚡️ It’s basically deleting the bad parts, a chunk of seconds at a time—like that tangent you go on, that five-second period where you stammer over a word, and those dozens of “umm”s and “like”s you had no idea you said so often. Ripple delete couldn’t be easier or more essential, and it’s available in both Camtasia and Screenflow. 🙌
 
 In the egghead lesson shown below, John Lindquist shows how he uses ripple delete to trim a video from 7:28 to 2:17. Yes, really.
 
@@ -14,7 +14,7 @@ https://www.dropbox.com/s/a5ahcas02qtxu99/egghead-edit-with-ripple-delete.mp4?dl
 
 
 
-## Editing with Premiere
+### Editing with Premiere
 
 In time, you can 💥 kick it up a notch 💥 with more sophisticated editing software like Adobe Premiere. Premiere has some significant advantages, but it also has a steep learning curve. We recommend starting simple, and leveling up to a non-linear editing system like Premiere later. If you’re interested, see how some of our advanced instructors use Premiere:
 
@@ -23,7 +23,7 @@ In time, you can 💥 kick it up a notch 💥 with more sophisticated editing so
 - [Voiceover and editing with Joel Hooks](https://www.youtube.com/watch?v=faINApx4-4g&list=PL219naRJXQKbQJ60WxsuGfTFv7_fvna51&index=2)
 
 
-## The easiest way to edit is to capture it well
+### The easiest way to edit is to capture it well
 
 In traditional videography, “in-camera editing” refers to the idea of capturing content so well, it doesn’t need to be edited much at all.
 

--- a/instructor-guide/docs/04-Screencasting-tips/04-Edit-your-lesson.md
+++ b/instructor-guide/docs/04-Screencasting-tips/04-Edit-your-lesson.md
@@ -34,6 +34,3 @@ Your first few lessons will feel like a major effort to produce because you have
 Believe us: You’ll get better. And better. And better. Just keep practicing and keep recording.
 
 Need help or advice? Please, #ask! You aren’t the first person to do this or struggle at it. Your coach and the other friendly folks on Slack were all in your shoes once, and now we’re here to help you succeed.
-
-Next up → [Sharing your code](https://paper.dropbox.com/doc/05-Sharing-your-code-XPt8sCs1hyoeAEuyK8aQr)
-

--- a/instructor-guide/docs/04-Screencasting-tips/05-Sharing-your-code.md
+++ b/instructor-guide/docs/04-Screencasting-tips/05-Sharing-your-code.md
@@ -89,6 +89,3 @@ Also note that
 **9)** Then the two `SystemJS.config` objects can be added in their own script. Now you’re good to go!
 
 Here’s [one last example of a Plunker embed](http://embed.plnkr.co/UxkIoIK9PEkaupwTInDE?show=script.js,preview) to send you on your way.
-
-Next up → [Host a demo REST API](https://paper.dropbox.com/doc/06-Host-a-demo-REST-API-sHtdZV7OTO4F2CfSwo0Is)
-

--- a/instructor-guide/docs/04-Screencasting-tips/05-Sharing-your-code.md
+++ b/instructor-guide/docs/04-Screencasting-tips/05-Sharing-your-code.md
@@ -1,48 +1,48 @@
-# 05 - Sharing your code
+## Sharing your code
 Playing around with code is critical to becoming a better web developer.
 
 For every egghead lesson, we provide a concise, organized, readable code example below the lesson video in a runnable embed, using Plunker or a similar service. That way, egghead members can jump in right away.
 
-Note: You should always record in a local environment using your favorite text editor, and then repurpose your code using Plunker or your service of choice. You do you! 
+Note: You should always record in a local environment using your favorite text editor, and then repurpose your code using Plunker or your service of choice. You do you!
 
 
-## Using Plunker
+### Using Plunker
 
 Plunker allows us to embed even fairly complex apps as runnable examples, perfect for our learners to run with. There are two ways to use it:
 
 - You’ll typically use **Plunker’s public UI** and set up your code example there. For standalone lessons, feel free to just do this. It works great.
-- Plunker also supports loading your code **directly into the embed via Github**. This is an amazing feature that allows us to version control the examples presented to the user. egghead can then handle maintenance on your examples and keep them updated and supported for a much longer time. :muscle:  
+- Plunker also supports loading your code **directly into the embed via Github**. This is an amazing feature that allows us to version control the examples presented to the user. egghead can then handle maintenance on your examples and keep them updated and supported for a much longer time. :muscle:
 
-Much as we love Plunker, there are cases where it just won’t work. In those cases, simply link to a GitHub repository. 
+Much as we love Plunker, there are cases where it just won’t work. In those cases, simply link to a GitHub repository.
 
 
-## Link a Plunker embed to a GitHub repo
+### Link a Plunker embed to a GitHub repo
 
 Linking a GitHub repository to Plunker is fairly simple and involves configuring the Plunker embed url. We start with https://embed.plnkr.co/ , which is the base embed url. To link to Github we configure the url by adding:
 
-`https://embed.plnkr.co/github/{profile-name}/{repository}/{branch}``    
+`https://embed.plnkr.co/github/{profile-name}/{repository}/{branch}``
 
 `{branch}` can be replaced with `{tag|sha1}` depending on how your repo is set up. If your repo is set up with an example in individual folders, you can add that `/path` to the embed url.
 
 [Here’s an example Github repo](https://github.com/eggheadio-projects/nlp-in-javascript-with-natural), which is divided into one folder per lesson.
- 
+
 
 ![](https://lh4.googleusercontent.com/BN85gMdmTnjYqHeoEwsHzjtXWp-ihYBBQULZI4C6tz0jmyhGGTjnkHwEOiYqTMn3w28D7bvq9Lvgixz5QdBtQM8mfs7V1vfOgYiRQIaahBfd22lcHBqEqARyqgWhzPib478Gmgz2)
 
-## Additional Plunker embed config 
+### Additional Plunker embed config
 
 URL parameters can be added to affect how the embed presents itself. The most-used feature is showing specific files (the default being the index and preview). Add `?show=` to the end of the url with the various filenames separated by commas.
- 
+
 `https://embed.plnkr.co/github/eggheadio-projects/egghead-wikipedia-demo/angular-2-building`
 
-You’ll see a complex example of this [here](https://embed.plnkr.co/github/eggheadio-projects/egghead-wikipedia-demo/angular-2-building-an-instant-search-with-angular-2-combining-observables-with-flatmap?preview=plnkr.html&show=src%2Fapp%2Fapp.component.ts,preview). 
- 
+You’ll see a complex example of this [here](https://embed.plnkr.co/github/eggheadio-projects/egghead-wikipedia-demo/angular-2-building-an-instant-search-with-angular-2-combining-observables-with-flatmap?preview=plnkr.html&show=src%2Fapp%2Fapp.component.ts,preview).
+
 If you want to go wild, [this gist documents](https://ggoodman.gitbooks.io/plunker/content/embed.html) quite a few additional parameters you can use.
 
 
-## Build complex apps in Plunker
+### Build complex apps in Plunker
 
-Before you go any further, **stop!** You don’t need to build apps in Plunker. egghead will do this for you. Just hit up @zac in Slack and we’ll get to it. 
+Before you go any further, **stop!** You don’t need to build apps in Plunker. egghead will do this for you. Just hit up @zac in Slack and we’ll get to it.
 
 ...but if you’re the DIY type, this is actually pretty cool.
 
@@ -58,17 +58,17 @@ Here’s what you do.
 
 **3)** Select all the defaults given to you. Then run:
 `$ jspm i npm:{package_you_want_to_install}`
-For instance: `jspm i npm:data.task` This will give a verbose working example of the config file needed to achieve in-browser compiling. 
+For instance: `jspm i npm:data.task` This will give a verbose working example of the config file needed to achieve in-browser compiling.
 
 **4)** After init is done, this is the barebones .html page you will need:
 
 ![](https://lh3.googleusercontent.com/QfBRAe4xp95hUC9bSIhOaSanvInun0erAoUtjBQTdZ9AldfSC_-aOj-2nv1gbCf28B3MXmQK46WI0ABJCBbP8FBwjY2F-c8nmWOr79KsqIWWw5QaD2TsX4-nWEbXUGBEeJGZd1aE)
 
 
-**5)** You then need to create an `app.js` file in the `src` directory `src/app.js` . This file will contain the code you want to run. Any packages that are installed using 
+**5)** You then need to create an `app.js` file in the `src` directory `src/app.js` . This file will contain the code you want to run. Any packages that are installed using
 `jspm i npm:{package_you_want_to_install}` will create a `jspm_packages/npm/{package_you_want_to_install}@1.2.3.json` file.
 
-**6)** ⚡️ Copy those contents. ⚡️ 
+**6)** ⚡️ Copy those contents. ⚡️
 The content will be placed in your `SystemJS.config` under the packages property as the package you installed. For instance:
 
 ![](https://lh5.googleusercontent.com/8j8p214IkMmQBkcdc9Y8m4ctaHcRfZGMksRnYHJ3IOa0y0okvb6TE0gVjZu-8a0qL_S_XRFnayxS1ID9yEh_EYuIbum_Arlwriy9sFeIaCLiausO2wqcFmUwFnFPeLLo9V5_Y4T9)
@@ -81,14 +81,14 @@ The content will be placed in your `SystemJS.config` under the packages property
 
 Note that the `"baseURL":` property was changed from `/` to a `.`
 
-Also note that 
-`"systemjs-babel-build": "npm:systemjs-plugin-babel/systemjs-babel-browser.js` **line was added under the** `map` property (nested in the `devConfig` property). 
+Also note that
+`"systemjs-babel-build": "npm:systemjs-plugin-babel/systemjs-babel-browser.js` **line was added under the** `map` property (nested in the `devConfig` property).
 
-**8)** For Plunker apps, just add this script tag (in `index.html` ): `<scriptsrc="https://unpkg.com/systemjs@0.19.41/dist/system.src.js"></script>` 
+**8)** For Plunker apps, just add this script tag (in `index.html` ): `<scriptsrc="https://unpkg.com/systemjs@0.19.41/dist/system.src.js"></script>`
 
-**9)** Then the two `SystemJS.config` objects can be added in their own script. Now you’re good to go! 
+**9)** Then the two `SystemJS.config` objects can be added in their own script. Now you’re good to go!
 
-Here’s [one last example of a Plunker embed](http://embed.plnkr.co/UxkIoIK9PEkaupwTInDE?show=script.js,preview) to send you on your way. 
- 
+Here’s [one last example of a Plunker embed](http://embed.plnkr.co/UxkIoIK9PEkaupwTInDE?show=script.js,preview) to send you on your way.
+
 Next up → [Host a demo REST API](https://paper.dropbox.com/doc/06-Host-a-demo-REST-API-sHtdZV7OTO4F2CfSwo0Is)
 

--- a/instructor-guide/docs/04-Screencasting-tips/06-Host-a-demo-REST-API.md
+++ b/instructor-guide/docs/04-Screencasting-tips/06-Host-a-demo-REST-API.md
@@ -1,8 +1,8 @@
-# 06 - Host a demo REST API
+## Host a demo REST API
 Want data to play around with in your next egghead lesson?
- 
+
 egghead co-founder and instructor extraordinaire John Lindquist set us up with a REST API using [swapi](https://swapi.co/) (The Star Wars API) and [json-server](https://github.com/johnlindquist/swapi-json-server). As long as you don’t openly endorse or promote swapi (or Star Wars), you’ll have no issues with copyrights.
- 
+
 If you don’t have a need for any special configurations, you can spin up the server using [npx](https://github.com/zkat/npx).
 
 npx ships with the latest versions of npm, so you probably already have it installed.
@@ -11,45 +11,45 @@ npx ships with the latest versions of npm, so you probably already have it insta
 `// --> http://localhost:3000`
 
 
-💥 Presto. You’re now running a REST API using Star Wars data. 💥 
- 
+💥 Presto. You’re now running a REST API using Star Wars data. 💥
 
-## Build custom data for egghead lessons 
+
+### Build custom data for egghead lessons
 
 Of course, you have endless options for building a REST API.
- 
-If your data needs to be unique for the lesson you’re crafting (there’s a lesson for that!), John shows us [how to generate a large dataset of JSON data](https://egghead.io/lessons/javascript-creating-demo-apis-with-json-server)
- 
 
-## 100 random people 
+If your data needs to be unique for the lesson you’re crafting (there’s a lesson for that!), John shows us [how to generate a large dataset of JSON data](https://egghead.io/lessons/javascript-creating-demo-apis-with-json-server)
+
+
+### 100 random people
 
 If 100 random people is enough for your data set, grab this gist: [100 people in JSON format](https://gist.github.com/johnlindquist/3a7d28dbf231c476d62dd3f481d7b1c5).
- 
 
-## Serve JSON locally 
+
+### Serve JSON locally
 
 `json-server` will serve any JSON file we have ready.
- 
+
 `$ npm i -g json-server`
 
 `$ json-server {data.json}`
- 
-You're good to go.
- 
 
-## Host a REST API 
+You're good to go.
+
+
+### Host a REST API
 
 Zeit's [now](https://zeit.co/now) feature is a great way to host any application needing it.
- 
+
 You can use the now  command with an app John set up:
 
 `$ npm i -g now`
 `$ now https://github.com/johnlindquist/swapi-json-server`
 
 If this is your first time using now, there will be a small amount of setup, but overall it's a breeze.
- 
+
 There’s a lesson for that, too. Check out [Deploy Web Apps with Zeit Now](https://egghead.io/courses/deploy-web-apps-with-zeit-now) for an in-depth look at `now`. Watch it right now!
- 
+
 Next chapter → [odds and ends](https://paper.dropbox.com/folder/show/05-odds-and-ends-e.1gg8YzoPEhbTkrhvQwJ2zz3VffojOHPOdfu3rIpIvmaXudxK3Eny)
 Next up → [egghead on Slack](https://paper.dropbox.com/doc/01-egghead-on-Slack-VSi6vqVpXCmyahsf660Y2)
 

--- a/instructor-guide/docs/04-Screencasting-tips/06-Host-a-demo-REST-API.md
+++ b/instructor-guide/docs/04-Screencasting-tips/06-Host-a-demo-REST-API.md
@@ -49,8 +49,3 @@ You can use the now  command with an app John set up:
 If this is your first time using now, there will be a small amount of setup, but overall it's a breeze.
 
 There’s a lesson for that, too. Check out [Deploy Web Apps with Zeit Now](https://egghead.io/courses/deploy-web-apps-with-zeit-now) for an in-depth look at `now`. Watch it right now!
-
-Next chapter → [odds and ends](https://paper.dropbox.com/folder/show/05-odds-and-ends-e.1gg8YzoPEhbTkrhvQwJ2zz3VffojOHPOdfu3rIpIvmaXudxK3Eny)
-Next up → [egghead on Slack](https://paper.dropbox.com/doc/01-egghead-on-Slack-VSi6vqVpXCmyahsf660Y2)
-
-

--- a/instructor-guide/docs/05-odds-and-ends/01-egghead-on-Slack.md
+++ b/instructor-guide/docs/05-odds-and-ends/01-egghead-on-Slack.md
@@ -1,41 +1,41 @@
-# 01 - egghead on Slack
-Slack is where egghead communicates. 
+## egghead on Slack
+Slack is where egghead communicates.
 
-There’s a Slack channel for almost every element of egghead. Some channels are specific to instructors and lesson creation. Some are just for fun. All are meant to keep you connected to the egghead community and help you become the best instructor you can be. 
+There’s a Slack channel for almost every element of egghead. Some channels are specific to instructors and lesson creation. Some are just for fun. All are meant to keep you connected to the egghead community and help you become the best instructor you can be.
 
 If you ever need anything, #ask!
 
 
-## Your private instructor channel
+### Your private instructor channel
 
 Right when you get started on egghead, we’ll set up a private channel for you. Here, you can work with your coach and other top-tier instructors to nail egghead style and get your first lesson published. Feel free to ask any questions, brainstorm ideas for your first lessons and courses, and share drafts. We’re here to help.
 
 
-## #egghead-chat
+### #egghead-chat
 
 This is the "water cooler" channel, where basically anything goes (within the general code of conduct, of course). Many egghead instructors are freelancers or work at home, so this gives us a place to socialize and talk about programming and industry stuff. It is noisy, so you might be compelled to mute this channel, but it’s always here when you need it.
 
 
-## #egghead-instructors
+### #egghead-instructors
 
 Creating bite-sized code videos is an art form. This is where we discuss it. This channel is a great place to solicit feedback from other instructors and the wider egghead team about your latest lesson ideas, course proposals, and drafts. We've got an amazing group of experienced instructors who are happy to help you. It’s a great community, and you should lean on it whenever you need to.
 
 
-## #egghead-publishing-queue
+### #egghead-publishing-queue
 
 This is where egghead’s publishing activity is announced by bots. When a lesson is uploaded, or a course/lesson is published, it’s automatically announced in this channel. Keep an eye on it from time to time to see what’s coming down the pike.
 
 
-## #egghead-lesson-ideas
+### #egghead-lesson-ideas
 
 There are so many things to teach about in the world of web development. When we see something interesting or get a request, it gets dropped in here. If you can't think of anything to record a lesson about, ask in here with @joel . There’s always something to teach! 🙂
 
 
-## Etcetera
+### Etcetera
 
 We've got other channels for specific topics like music & tv, fitness, functional programming, and podcasts. Surprise surprise, egghead instructors are passionate people.
 
-Like most Slack groups, members are welcome to make public and private channels, DM with anyone, litter every channel with emoji and gifs, and even add integrations. Use your good judgment, and if you have any questions, please feel free to #ask. 
+Like most Slack groups, members are welcome to make public and private channels, DM with anyone, litter every channel with emoji and gifs, and even add integrations. Use your good judgment, and if you have any questions, please feel free to #ask.
 
 Next up → [Our contributor agreement](https://paper.dropbox.com/doc/02-Our-contributor-agreement-Spxagu3vtsQ4SJhPZ3Bcf)
 

--- a/instructor-guide/docs/05-odds-and-ends/01-egghead-on-Slack.md
+++ b/instructor-guide/docs/05-odds-and-ends/01-egghead-on-Slack.md
@@ -36,6 +36,3 @@ There are so many things to teach about in the world of web development. When we
 We've got other channels for specific topics like music & tv, fitness, functional programming, and podcasts. Surprise surprise, egghead instructors are passionate people.
 
 Like most Slack groups, members are welcome to make public and private channels, DM with anyone, litter every channel with emoji and gifs, and even add integrations. Use your good judgment, and if you have any questions, please feel free to #ask.
-
-Next up → [Our contributor agreement](https://paper.dropbox.com/doc/02-Our-contributor-agreement-Spxagu3vtsQ4SJhPZ3Bcf)
-

--- a/instructor-guide/docs/05-odds-and-ends/02-Our-contributor-agreement.md
+++ b/instructor-guide/docs/05-odds-and-ends/02-Our-contributor-agreement.md
@@ -1,5 +1,5 @@
-# 02 - Our contributor agreement
-egghead has a [standard contributor agreement](https://docs.google.com/document/d/17jNT6R6SNb9OVYSnpTDqevMh80XZ8Gu3VeYoLZck0v4/edit) that we provide to all instructors. The agreement protects egghead from any mischief you might cause; leaves all ownership rights to you, the creator; and lays out the terms for payment. You sign it, we sign it, we shake on it. 
+## Our contributor agreement
+egghead has a [standard contributor agreement](https://docs.google.com/document/d/17jNT6R6SNb9OVYSnpTDqevMh80XZ8Gu3VeYoLZck0v4/edit) that we provide to all instructors. The agreement protects egghead from any mischief you might cause; leaves all ownership rights to you, the creator; and lays out the terms for payment. You sign it, we sign it, we shake on it.
 
-We like to maintain respectful, easygoing, rewarding relationships with our contributors. This agreement allows everyone to happily work together for years on end. 
+We like to maintain respectful, easygoing, rewarding relationships with our contributors. This agreement allows everyone to happily work together for years on end.
 


### PR DESCRIPTION
- Adjusted headings to be a smaller size
- Removed the numbers from chapter titles (this was to keep things in order in dropbox paper)
- Removed the "next up" links (they were linking to paper docs)
