### PR TITLE
fix: avoid randomly itty bitty images

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -31,7 +31,6 @@ module.exports = {
             resolve: 'gatsby-remark-images',
             options: {
               maxWidth: 960,
-              sizeByPixelDensity: true,
               linkImagesToOriginal: false,
             },
           },


### PR DESCRIPTION
In testing, the pixel density of some images is coming back _really_ weird (for one, it was `1829`). There's not a ton of value in sizing by pixel density since the images end up being the same size anyways, so turning off this setting _should_ eliminate the image size weirdness.

For context, the calculation is being done in `gatsby-plugin-sharp`.

We're looking into whether this is a bug or a consequence of weird image metadata. In the meantime, this ought to eliminate the issue.