### PR TITLE
fix: correct broken link in Chrome plugins doc

### DIFF
--- a/src/content/reviewerGuide/02-Setup/02-Chrome-Plugins.mdx
+++ b/src/content/reviewerGuide/02-Setup/02-Chrome-Plugins.mdx
@@ -11,4 +11,4 @@ The React Developer Tools extension is needed for reviewing our React course con
 
 ### Video Speed Controller
 Video Speed Controller allows you to quickly adjust the video speed with your keyboard.
-Install it here: [Video Speed Controller](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi)
+Install it here: [Video Speed Controller](https://chrome.google.com/webstore/detail/video-speed-controller/nffaoalbilbmmfgbnbgppjihopabppdk)


### PR DESCRIPTION
Noticed this broken link in this doc (both links went to the React DevTools), cheers!