### PR TITLE
move the homepage to point at new version of the guide

### DIFF
--- a/content/index.mdx
+++ b/content/index.mdx
@@ -1,0 +1,13 @@
+---
+date: 2019-01-01
+title: 'How to egghead'
+description: 'This is the source'
+published: true
+---
+
+Welcome to `how to egghead`. This site explains https://egghead.io for folks that use it. Right now it is focused on two groups of people. The first is the egghead instructor. Somebody that is teaching on egghead. The second is the egghead content reviewer. These are the folks that help produce and maintain content for egghead instructors and learners.
+
+- [👩‍🏫 instructor guide](/instructor)
+- [👩‍🔧 content reviewer guide](/reviewer)
+
+We are currently migrating this site to a new structure and format. The old version can be [found here](/what-is-egghead) in the meantime. It's also [avalaible on github](https://github.com/eggheadio/how-to-egghead) if you'd like to contribute or just poke around.

--- a/src/content/instructorGuide/00-What-is-egghead.mdx
+++ b/src/content/instructorGuide/00-What-is-egghead.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'What is egghead'
-slug: '/'
+slug: '/what-is-egghead'
 ---
 
 # What is egghead?


### PR DESCRIPTION
We need to not have two versions of the guide so this is going to be a priority to get the new version up and running. It's visually less interesting @vojtaholik, but maybe best to keep it "just text" for now? 
![](https://media.giphy.com/media/l4q8aiEXxYe5KdBte/giphy.gif)