### PR TITLE
temp fix of double images

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -37,6 +37,7 @@ module.exports = {
         ],
       },
     },
+    'gatsby-remark-images',
     'gatsby-transformer-remark',
     'gatsby-plugin-react-helmet',
     {
@@ -126,7 +127,9 @@ module.exports = {
                 const {title, description} = node.frontmatter
                 const path = node.fields.slug
                 // for old guides, we take slug from frontmatter, while for the new one from fields
-                const slug = node.frontmatter.slug ? `/${node.frontmatter.slug}` : node.fields.slug
+                const slug = node.frontmatter.slug
+                  ? `/${node.frontmatter.slug}`
+                  : node.fields.slug
                 const {excerpt} = node.excerpt
                 const base = {slug, title, path, excerpt, description}
                 const chunks = node.rawBody.split('\n\n')


### PR DESCRIPTION
includes remark images plugin in the root plugins array.

![fix-double-images](https://user-images.githubusercontent.com/25487857/64564179-42eab300-d351-11e9-85e8-058d5a988eff.png)


related: https://github.com/gatsbyjs/gatsby/issues/16242