### PR TITLE
Fix article links in how-to-teach

### DIFF
--- a/content/instructor/style-guide/what-to-teach/index.mdx
+++ b/content/instructor/style-guide/what-to-teach/index.mdx
@@ -71,15 +71,15 @@ _[Image: Something like detailing a car...showing very precise work.]_
 
 Create these three supporting materials:
 
-- [**Your lesson title**](/write-the-title-and-summary). Use that “How do I” trick. Does it work for your topic? Does your title cover one thing clearly—and can you cover that thing in a short amount of time? Then you’re good.
-- [**Your lesson summary**](/write-the-title-and-summary). If it’s too long or requires a lot of detail to summarize, you might need to reduce the lesson’s scope.
-- [**The code example**](/create-your-code-example) you’ll use to demonstrate the lesson concept. It should be easy to run with very few simple steps. If it requires several steps and screens—and if you anticipate needing to give a lot of background and contextual information to explain those steps—tighten your scope.
+- [**Your lesson title**](/instructor/style-guide/thinking-in-lessons). Use that “How do I” trick. Does it work for your topic? Does your title cover one thing clearly—and can you cover that thing in a short amount of time? Then you’re good.
+- [**Your lesson summary**](/instructor/style-guide/thinking-in-lessons). If it’s too long or requires a lot of detail to summarize, you might need to reduce the lesson’s scope.
+- [**The code example**](/instructor/style-guide/create-the-example-code) you’ll use to demonstrate the lesson concept. It should be easy to run with very few simple steps. If it requires several steps and screens—and if you anticipate needing to give a lot of background and contextual information to explain those steps—tighten your scope.
 
 Think of these items as the outline you’d create before writing a school essay. If that outline gets too long and ambitious, you need to reel in the scope a bit.
 
 ### That lesson already exists? Do it anyway!
 
-We have zero qualms about repeating topics. Actually, [we encourage it](/what-if-a-lesson-already-exists). No one knows exactly what you know or phrases things in your particular way. What’s your take? Tell us! Tell everybody.
+We have zero qualms about repeating topics. Actually, [we encourage it](/instructor/style-guide/lesson-already-exists). No one knows exactly what you know or phrases things in your particular way. What’s your take? Tell us! Tell everybody.
 
 ### Slack us!
 


### PR DESCRIPTION
## Changes made
- there were a few links that went to routes that have been removed from howtoegghead. This fixes that!


![](https://media2.giphy.com/media/SJk9xTbxcg0DFDs89d/giphy.gif?cid=5a38a5a2b967ca1d2f04e51d67388b356ab30132ffe6dcb4&rid=giphy.gif)
