### PR TITLE
edit article: the egghead pro equipment

### DIFF
--- a/content/instructor/screencasting/audio-equipment/index.mdx
+++ b/content/instructor/screencasting/audio-equipment/index.mdx
@@ -4,7 +4,7 @@ title: 'The egghead pro audio equipment'
 description: 'Every egghead instructor receives an amazing world class pro audio recording setup before they publish their first lesson.'
 categories: ['instructor']
 published: true
-shareImage: 'https://res.cloudinary.com/dg3gyk0gu/image/upload/v1571260698/og-image-assets/share_image_screencasting.png'
+shareImage: 'https://res.cloudinary.com/dg3gyk0gu/image/upload/v1583832106/og-image-assets/audio-equipment-3.png'
 redirect_from:
   - /set-up-your-audio/
   - /set-up-your-audio
@@ -17,6 +17,12 @@ Amazing audio quality starts with quality gear. Your laptop’s built-in microph
 When you become an egghead instructor, we hook you up! As soon as you have a draft lesson almost ready to publish, we’ll send you a waterproof Pelican case full of professional-grade audio recording equipment. 📬
 
 ![photo of open case with egghead gear inside](./images/audio-setup/open-case.jpg)
+
+<Grid columns={2} gap={'1rem'}>
+<TwitterTweetEmbed tweetId={'1096872894695723008'} options={{ conversation: 'none', align: 'center', width: '100%' }} />
+<TwitterTweetEmbed tweetId={'998939239361470466'} options={{ conversation: 'none', align: 'center', width: '100%' }} />
+</Grid>
+<br/>
 
 Here’s what you’ll be getting:
 
@@ -71,14 +77,26 @@ XLR is a plug used in professional audio applications. It isn't completely neces
 
 ![XLR](https://camo.githubusercontent.com/77d44222dc0a0650ef799c95e716ee9d1aa44592/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f662e636c2e6c792f6974656d732f326933393371314a30483059314f3139325931452f496d616765253230323031362d30342d31392532306174253230312e33382e3539253230504d2e6a70673f763d3066656435333337)
 
+### Set up the gear to record lessons
+
+<ResponsiveEmbed src="https://egghead.io/lessons/tools-setup-egghead-audio-gear-to-record-lessons/embed" />
+<br/>
+
 Your final setup should look something like this:
 
 ![photo of setup all done](./images/audio-setup/full-set-up.jpg)
+
 
 ### Check audio input levels
 
 Once your gear is set up, you'll need to check the audio input levels to make sure your gain is set properly. Here’s a lesson to help you:
 
 <ResponsiveEmbed src="https://egghead.io/lessons/tools-prepare-to-record-screen-resolution-and-mic-check/embed" />
+<br/>
 
 Ta-da! You’re ready to record.
+
+<div style={{display: 'grid', gridTemplateColumns: '1fr 1fr', gridTemplateRows: 'auto', gridGap: '1rem'}}>
+<TwitterTweetEmbed tweetId={'1166838770198405120'} options={{ conversation: 'none', align: 'center', width: '100%' }} />
+<TwitterTweetEmbed tweetId={'1082999320394285056'} options={{ conversation: 'none', align: 'center', width: '100%' }} />
+</div>


### PR DESCRIPTION
- adds a new share card: 
![The egghead pro audio equipment](https://user-images.githubusercontent.com/25487857/76299439-615b4800-62bb-11ea-80f3-395883697d0e.png)

- adds tweet embeds of instructors receiving their gear

- adds embed of [this lesson on how to set it up ](https://egghead.io/lessons/tools-setup-egghead-audio-gear-to-record-lessons)


![gear](https://user-images.githubusercontent.com/25487857/76299656-c4e57580-62bb-11ea-852d-4422b1efa83a.png)


<img src="https://media.giphy.com/media/m9q7Rw5w3s58tAA0KR/giphy.gif" width="250">