### PR TITLE
Update 'Setup your Mac terminal for screencasting' article with new lesson embed

### DIFF
--- a/content/instructor/screencasting/terminal/index.mdx
+++ b/content/instructor/screencasting/terminal/index.mdx
@@ -37,7 +37,6 @@ Use custom `ENV` variables if you prefer to only customize the PS1 Bash/Zsh comm
 In VS Code, add a new property, `terminal.integrated.env.osx`, and a new variable that will run a value.
 
 ```json
-// settings.json
 {
   "terminal.integrated.env.osx": {
     "VSC": "yes lol!"
@@ -48,11 +47,9 @@ In VS Code, add a new property, `terminal.integrated.env.osx`, and a new variabl
 Open zsh resource file, `~/.zshrc` and add a simple check at the end of the file to handle the case when the terminal is open in VS Code. Save and reload everything.
 
 ```shell
-# .zshrc
 if [ "$VSC" = "yes lol!"], then
   PS1='\$ '
 fi
-
 ```
 
 This works in Bash with `~/.bashrc` as well.

--- a/content/instructor/screencasting/terminal/index.mdx
+++ b/content/instructor/screencasting/terminal/index.mdx
@@ -7,7 +7,7 @@ published: true
 shareImage: 'https://res.cloudinary.com/dg3gyk0gu/image/upload/v1571260698/og-image-assets/share_image_screencasting.png'
 ---
 
-import EggheadEmbed from '../../../../src/components/eggheadEmbed';
+import EggheadEmbed from '../../../../src/components/eggheadEmbed'
 
 If you will be showing your command line, we suggest using a minimal prompt to reduce distractions. This example prompt works well for screencasting:
 
@@ -25,7 +25,36 @@ Note: If you’re on Mac and using Bash, you also need to add a `~/.bash_profile
 
 This tells Mac to load your `~/.bashrc` when loading a terminal emulator.
 
+## Customize the Command Prompt in VS Code
+
 <EggheadEmbed
   lessonTitle="Customize the PS1 Bash/Zsh Command Prompt in VS Code with Environment Variables"
   lessonLink="https://egghead.io/lessons/git-add-more-files-and-changes-to-a-commit-before-pushing/embed"
 />
+
+Use custom `ENV` variables if you prefer to only customize the PS1 Bash/Zsh command prompt in the VS Code terminal without affecting your other custom terminal themes in other applications, such as iTerm2.
+
+In VS Code, add a new property, `terminal.integrated.env.osx`, and a new variable that will run a value.
+
+```json
+// settings.json
+{
+  "terminal.integrated.env.osx": {
+    "VSC": "yes lol!"
+  }
+}
+```
+
+Open zsh resource file, `~/.zshrc` and add a simple check at the end of the file to handle the case when the terminal is open in VS Code. Save and reload everything.
+
+```shell
+# .zshrc
+if [ "$VSC" = "yes lol!"], then
+  PS1='\$ '
+fi
+
+```
+
+This works in Bash with `~/.bashrc` as well.
+
+Now, the command prompt is now a `$` sign in VS Code's terminal while keeping other custom terminal themes intact.

--- a/content/instructor/screencasting/terminal/index.mdx
+++ b/content/instructor/screencasting/terminal/index.mdx
@@ -7,6 +7,8 @@ published: true
 shareImage: 'https://res.cloudinary.com/dg3gyk0gu/image/upload/v1571260698/og-image-assets/share_image_screencasting.png'
 ---
 
+import EggheadEmbed from '../../../../src/components/eggheadEmbed';
+
 If you will be showing your command line, we suggest using a minimal prompt to reduce distractions. This example prompt works well for screencasting:
 
 ![](https://lh3.googleusercontent.com/TouVkaQl8WDHTdHxr-u8PiALhO8MVjuOm1m05dtK6k8s2BPbcNDJe6pPH7Q0YXpVBUE0gH5ykLFbYq5VXGghJ---2FrdBhnRi5iGUQSA3Cdfxa2ohb-GfOXIGrTq0S1FKOVsD1wd)
@@ -23,3 +25,7 @@ Note: If you’re on Mac and using Bash, you also need to add a `~/.bash_profile
 
 This tells Mac to load your `~/.bashrc` when loading a terminal emulator.
 
+<EggheadEmbed
+  lessonTitle="Customize the PS1 Bash/Zsh Command Prompt in VS Code with Environment Variables"
+  lessonLink="https://egghead.io/lessons/git-add-more-files-and-changes-to-a-commit-before-pushing/embed"
+/>

--- a/src/components/eggheadEmbed.js
+++ b/src/components/eggheadEmbed.js
@@ -5,6 +5,7 @@ const EggheadEmbed = ({ lessonLink, lessonTitle }) => (
     style={{
       position: 'relative',
       paddingBottom: '56.2%',
+      marginBottom: '40px',
     }}
   >
     <iframe

--- a/src/components/eggheadEmbed.js
+++ b/src/components/eggheadEmbed.js
@@ -1,0 +1,27 @@
+import React from 'react';
+
+const EggheadEmbed = ({ lessonLink, lessonTitle }) => (
+  <div
+    style={{
+      position: 'relative',
+      paddingBottom: '56.2%',
+    }}
+  >
+    <iframe
+      width="100%"
+      height="100%"
+      src={lessonLink}
+      title={lessonTitle}
+      frameBorder="0"
+      allow="accelerometer; encrypted-media; gyroscope; picture-in-picture"
+      allowFullScreenstyle="position: absolute;width: 100%;height: 100%;"
+      style={{
+        position: 'absolute',
+        width: '100%',
+        height: '100%',
+      }}
+    />
+  </div>
+);
+
+export default EggheadEmbed;

--- a/src/gatsby-plugin-theme-ui/index.js
+++ b/src/gatsby-plugin-theme-ui/index.js
@@ -3,7 +3,7 @@ import {lighten} from '@theme-ui/color'
 export default {
   colors: {
     primary: '#1b6ac9',
-    text: '#111',
+    text: '#111', 'code-text': '#444',
     background: '#fff',
     'gray-50': '#fafafa',
     'gray-100': '#f5f5f5',
@@ -92,6 +92,15 @@ export default {
         borderTop: '2px solid',
         borderTopColor: 'gray-100',
         mx: [-3, -5],
+      },
+      code: {
+        backgroundColor: 'gray-100',
+        color: 'code-text',
+      },
+      pre: {
+        backgroundColor: 'gray-100',
+        padding: '10px',
+        borderRadius: '6px',
       },
     },
   },

--- a/src/gatsby-plugin-theme-ui/index.js
+++ b/src/gatsby-plugin-theme-ui/index.js
@@ -96,6 +96,8 @@ export default {
       code: {
         backgroundColor: 'gray-100',
         color: 'code-text',
+        padding: '5px 6px',
+        borderRadius: '3px',
       },
       pre: {
         backgroundColor: 'gray-100',


### PR DESCRIPTION
Ready for for review: 

- [x] added responsive video embed
- [x] lesson summarized 
- [x] styled the pre and code tags 

[Netlify preview](https://deploy-preview-127--how-to-egghead.netlify.com/instructor/screencasting/terminal/)

**Note:** video controls no longer showing up on embeds, I filled an issue [here](https://github.com/eggheadio/egghead-rails/issues/3908).

