### PR TITLE
add cohort onboarding article

### DIFF
--- a/content/instructor/getting-started/onboarding/index.mdx
+++ b/content/instructor/getting-started/onboarding/index.mdx
@@ -19,7 +19,7 @@ We will also start talking about what your [first collection of lessons](/instru
 
 ## Week 2: Publish First Lesson, start a Second Lesson, and Plan a Collection
 
-Once your gear arrives via Fedex, you will set it up and record the final draft for your first lesson! 🎉
+Once your [gear arrives](/instructor/screencasting/audio-equipment) via Fedex, you will set it up and record the final draft for your first lesson! 🎉
 
 We will also pick another topic and record a single lesson on an important concept of that topic.
 

--- a/content/instructor/getting-started/onboarding/index.mdx
+++ b/content/instructor/getting-started/onboarding/index.mdx
@@ -1,0 +1,56 @@
+---
+date: 2020-04-29
+title: 'Instructor Cohort Timeline'
+description: 'This article describes the onboarding process for new instructors.'
+categories: ['instructor', 'getting-started']
+published: true
+shareImage: 'https://res.cloudinary.com/dg3gyk0gu/image/upload/v1571260698/og-image-assets/share_image_getting_started.png'
+---
+
+We start a new instructor cohort about every month. It will last for the full month, and the goal is to get you up to speed as a published egghead instructor over the month.
+
+During the month we are going to focus on a few goals:
+
+## Week 1: The First Lesson Draft and First Collection Brainstorming
+
+We will choose a topic and record a rough draft lesson. Once that is done we will send you [some audio equipment](/instructor/screencasting/audio-equipment).
+
+We will also start talking about what your [first collection of lessons](/instructor/collections) will be about. This might be an expansion of your first lesson or an entirely new example you'd like to teach. Once we figure out the idea, you will submit a proposal for your collection.
+
+## Week 2: Publish First Lesson, start a Second Lesson, and Plan a Collection
+
+Once your gear arrives via Fedex, you will set it up and record the final draft for your first lesson! 🎉
+
+We will also pick another topic and record a single lesson on an important concept of that topic.
+
+Once your first lesson is published we will [schedule a planning session](/instructor/workshops/planning-process) based on your collection proposal. This is a one hour session where we explore the ideas in your proposal, scope out the concepts and outcomes that the collection is delivering, and gain a mutually clear understanding of what you will teach.
+
+We like to keep the first collection relatively short, around ~5 lessons or so, so that it is achievable and realistic in scope. We are pretty good at assisting folks on how to scope these collections so you won't be expected to do all the work by yourself. We will be there at every step of the way.
+
+## Week 3: Another Single Lesson and the Example Code for Your Collection
+
+Now that we've got a scope and plan for producing a collection of related lessons, it's time to plan the example code that you will be teaching from. The example code provides a basis for the full scope of the collection, so we will be keeping it simple and achievable.
+
+We also encourage you to record (at least) one single lesson on a concept completely different from your planned collection.
+
+## Week 4: Start recording lessons for your collection
+
+Your collection is scoped.
+
+You've published several egghead lessons.
+
+You sound great through your professional audio equipment.
+
+Now it's time to record! 🤗
+
+This is the final week and the goal is to record and publish your collection.
+
+What's next?
+
+After week 4, **you can expect us to be there at every step of the way to help you** publish lessons, collections, workshops, and courses. We work on your schedule, and strive to support you as much as possible. Check out [these case studies](/instructor/case-studies) to get an idea of how we've collaborated with other instructors to help them achieve their goals as educators and entrepreneurs.
+
+We look forward to working with YOU on YOUR case study! 😀
+
+We will get you invited to Basecamp and our first group chat so we can discuss what to expect and meet the other instructors that will be participating this month as well.
+
+We're excited to collaborate with you.

--- a/content/instructor/getting-started/onboarding/index.mdx
+++ b/content/instructor/getting-started/onboarding/index.mdx
@@ -7,7 +7,7 @@ published: true
 shareImage: 'https://res.cloudinary.com/dg3gyk0gu/image/upload/v1571260698/og-image-assets/share_image_getting_started.png'
 ---
 
-We start a new instructor cohort about every month. It will last for the full month, and the goal is to get you up to speed as a published egghead instructor over the month.
+We start a new instructor cohort about every month to quarter depending on active interest. Each cohort will last for the full month, and the goal is to get you up to speed as a published egghead instructor over the month.
 
 During the month we are going to focus on a few goals:
 


### PR DESCRIPTION
# Changes made
- adds invite email copy to docs as an article detailing the onboarding process


I didn't link it anywhere in the docs but put it in the `/instructor/getting-started` folder.


![](https://media1.giphy.com/media/tsX3YMWYzDPjAARfeg/giphy.gif?cid=5a38a5a2f2cfdb4c8f476a3cbb70d50f9c5317ae6a4f6b16&rid=giphy.gif)
