### PR TITLE
hn/getting-started

### DIFF
--- a/content/instructor/getting-started/index.mdx
+++ b/content/instructor/getting-started/index.mdx
@@ -10,17 +10,17 @@ redirect_from:
   - /receiving-your-equipment
 ---
 
-If you've been invited to join the community of instructors creating badass screencasts on egghead you are probably wondering "now what?" 
+If you've been invited to join the community of instructors creating badass screencasts on egghead you are probably wondering "now what?"
 
 ![gold_invitation](./images/ch1_s4_invitation.png)
 
 First and foremost, welcome to egghead. We are very happy to have you and look forward to getting to know you better.
 
-- [Record your first 30-second egghead lesson](/instructor/getting-started/30-second-demo)
-- [egghead instructor gear](/instructor/screencasting/audio-equipment)
-- [Learn how egghead royalties work](/instructor/royalties)
-- [What's next after the 30-second demo lesson?](/instructor/getting-started/first-full-lesson)
-- [Email, Slack, and Zoom: how we communicate at egghead](/instructor/getting-started/communication)
+- [Record your first 30-second egghead lesson](#record-a-screencast-just-30ish-seconds-long)
+- [We provide feedback and support](#feedback-on-your-work-what-to-expect)
+- [Your egghead instructor gear](#dont-worry-about-audio-quality-yet-well-send-you-pro-style-gear)
+- [Learn how egghead royalties work](#you-will-be-paid-for-your-content) 💰
+- [Keeping it up](#keeping-it-up)
 
 We like to start small and increment. We don't begin the conversation discussing what your first 18 lesson workshop will be, instead we want to see a win. We want to communicate and collaborate and dial in our mutual expectations.
 
@@ -55,6 +55,8 @@ You want to dial in your:
 
 ![09_lesson_basics](./images/ch2_s4_lesson-basics.png)
 
+[What's next after the 30-second demo lesson?](/instructor/getting-started/first-full-lesson)
+
 ### Questions? Just #ask.
 
 We’re here to help you. Before you record your video, use your private Slack channel to fire over any questions or works in progress, like:
@@ -66,6 +68,8 @@ We’re here to help you. Before you record your video, use your private Slack c
 **We’re all about supportive, ongoing feedback at egghead**, so when you’re ready to press record, you’re _really_ ready.
 
 ![An illustration would work here too 🙂](https://media1.giphy.com/media/111ebonMs90YLu/giphy.gif)
+
+Learn more about [how we communicate at egghead](/instructor/getting-started/communication)!
 
 ### Feedback
 
@@ -113,7 +117,7 @@ We don't produce sponsored content or run ads. This doesn't mean that we avoid t
 
 We work with individuals, not companies. We work with developers who share their practical, valuable, production proven knowledge with other developers.
 
-[Read more about how royalties work here](/instructor/royalties)
+[Read more about how royalties work here](/instructor/royalties)!
 
 ### Keeping it up
 


### PR DESCRIPTION
# Changes Made
- Changed the links in the Table of Content to go to sections within the "Getting Started" page, and inserting the target links within the article sections where appropriate. 
- Hope is to create a more streamlined experience in term of reading from top to bottom.