### PR TITLE
Update description and add alt tags to images

### DIFF
--- a/content/instructor/case-studies/john-lindquist/index.mdx
+++ b/content/instructor/case-studies/john-lindquist/index.mdx
@@ -1,7 +1,7 @@
 ---
 date: 2019-01-01
 title: 'John Lindquist: The Original egghead'
-description: 'Kent C. Dodds has worked with egghead for most of his career as a developer. This is his story.'
+description: 'John is the original egghead. This is his story of how he started sharing his knowledge through screencasting and later build egghead with Joel Hooks'
 categories: ['instructor', 'case study']
 published: true
 shareImage: 'https://res.cloudinary.com/dg3gyk0gu/image/upload/v1573834774/og-image-assets/case-study-john-lindquist.png'
@@ -37,7 +37,7 @@ Although things have evolved as egghead has grown and more instructors have been
 
 The breadth and depth of the egghead courses that John has created over the past six years has been astounding. **He's shipped more than 450 lessons.**  
 
-![](./courses@2x.png)
+![Course illustrations that John has taught](./courses@2x.png)
 
 What started as a side-project became a radically life-changing dream come true for John as egghead has grown. In 2014, John had the financial freedom to be able to quit his job as a Technology Evangelist at JetBrains. He can now do what he loves to do full-time on his terms and spend more time with his family. 
 
@@ -55,11 +55,11 @@ While recording a concise screencast that is just a couple minutes long may seem
 
 He has taught countless people how to execute this very effective style of screencasting. He has helped train and mentor egghead instructors. John and Joel worked together to synthesize John's years of screencasting experience into the **[How to egghead](http://howtoegghead.com)** guide, which is freely available to anyone who wants to learn how to plan and execute badass screencasts. 
 
-![](./record-screencasts@2x.png)
+![Image of the record badass screencasts course](./record-screencasts@2x.png)
 
 Naturally, John created an egghead video course on how to create egghead-style screencasts, which is also available to everyone at no charge as a community resource. 
 
-![](./praise@2x.png)
+![5 star reviews telling us how great the screencast course is](./praise@2x.png)
 
 
 *Just a small sample of the reviews for John's freely available course on how to record high-quality video lessons for developers.* 


### PR DESCRIPTION
# Changes made
- Updated share description for John's case study
- add alt text for images

![](https://media2.giphy.com/media/65K0UvX0HXzaXBiE7x/giphy.gif?cid=5a38a5a27346a8ff92314362c825523d3df0eccdfcfbd233&rid=giphy.gif)
