### PR TITLE
hn/get invited

### DIFF
--- a/content/instructor/index.mdx
+++ b/content/instructor/index.mdx
@@ -39,7 +39,7 @@ children="Contributor Agreement"
 variant="secondary"
 />
 <Card
-href="/instructor/get-invited"
+href="/instructor/getting-started/get-invited"
 children="Get invited to teach on egghead"
 variant="secondary"
 />

--- a/content/instructor/index.mdx
+++ b/content/instructor/index.mdx
@@ -39,7 +39,7 @@ children="Contributor Agreement"
 variant="secondary"
 />
 <Card
-href="/instructor/getting-started/get-invited"
+href="/instructor/get-invited"
 children="Get invited to teach on egghead"
 variant="secondary"
 />


### PR DESCRIPTION
# Changes Made
- Updated the broken link for "get invited to teach on egghead" page on the instructor guide.