### PR TITLE
Update instructor onboarding outline

### DIFF
--- a/content/instructor/getting-started/onboarding/index.mdx
+++ b/content/instructor/getting-started/onboarding/index.mdx
@@ -9,48 +9,68 @@ shareImage: 'https://res.cloudinary.com/dg3gyk0gu/image/upload/v1571260698/og-im
 
 We start a new instructor cohort about every month to quarter depending on active interest. Each cohort will last for the full month, and the goal is to get you up to speed as a published egghead instructor over the month.
 
-During the month we are going to focus on a few goals:
+During the month we are going to focus on a few goals. 
 
-## Week 1: The First Lesson Draft and First Collection Brainstorming
+We will have 4 events focused on the topic of the week (as defined below). There is a preparation aspect for each event for you to discuss with the rest of the cohort. The goal of these events each week is for each of you to share and learn from each other.
+Everybody involved will be expected to do their best to prioritize and show up as a **Prepared Participant** having done the required work in between events.
 
-We will choose a topic and record a rough draft lesson. Once that is done we will send you [some audio equipment](/instructor/screencasting/audio-equipment).
+Each event will be as follows:
 
-We will also start talking about what your [first collection of lessons](/instructor/collections) will be about. This might be an expansion of your first lesson or an entirely new example you'd like to teach. Once we figure out the idea, you will submit a proposal for your collection.
+- Record Badass Screencasts
+- First Videos and Feedback Cycle
+- Kent C. Dodds - Recording an egghead video
+- Recording Lessons for Collections
 
-## Week 2: Publish First Lesson, start a Second Lesson, and Plan a Collection
+This is a breakdown of the month on a week by week basis: 
 
-Once your [gear arrives](/instructor/screencasting/audio-equipment) via Fedex, you will set it up and record the final draft for your first lesson! 🎉
+## Week 1: Demo Video and The First Lesson Draft
 
-We will also pick another topic and record a single lesson on an important concept of that topic.
+You've already put in some of the work for this week by completing the Instructor Application and uploading a demo lesson. We will have feedback ready for you when you join the Basecamp project to iterate on the demo lesson. 
 
-Once your first lesson is published we will [schedule a planning session](/instructor/workshops/planning-process) based on your collection proposal. This is a one hour session where we explore the ideas in your proposal, scope out the concepts and outcomes that the collection is delivering, and gain a mutually clear understanding of what you will teach.
+Next, we will choose a topic and record a rough draft lesson. If you'd like to continue with the demo that you recorded, that can be your first lesson.
 
-We like to keep the first collection relatively short, around ~5 lessons or so, so that it is achievable and realistic in scope. We are pretty good at assisting folks on how to scope these collections so you won't be expected to do all the work by yourself. We will be there at every step of the way.
+When your lesson is ready for a final draft recording, we will send you [some audio equipment](/instructor/screencasting/audio-equipment).
 
-## Week 3: Another Single Lesson and the Example Code for Your Collection
+## Week 2: Publish First Lesson, Start a Second Lesson, and Brainstorm First Collection
 
-Now that we've got a scope and plan for producing a collection of related lessons, it's time to plan the example code that you will be teaching from. The example code provides a basis for the full scope of the collection, so we will be keeping it simple and achievable.
+Once your [gear arrives](/instructor/screencasting/audio-equipment), you will set it up and record the final draft for your first lesson! 🎉
 
-We also encourage you to record (at least) one single lesson on a concept completely different from your planned collection.
+We will start iterating on your second lesson during the second week, this lesson should be a different topic and shouldn't be related to the first (we'll get to collection planning this week). 
+
+We will also start talking about what your [first collection of lessons](/instructor/collections) will be about. This might be an expansion of one of your lessons or an entirely new example you’d like to teach. Once we figure out the idea, you will submit a proposal for your collection.
+
+Once that proposal is submitted we will [schedule a planning session](/instructor/workshops/planning-process).
+
+## Week 3: Another Single Lesson and Plan the First Collection
+
+We'll start a 3rd individual lesson just like the previous week. You'll be getting the hang of this!
+
+The focus of this week will be planning out your first collection.
+
+We like to keep the first collection relatively short, around ~5 lessons, so that it is achievable and realistic in scope. We are pretty good at assisting folks on how to scope these collections so you won’t be expected to do all the work by yourself. We will be there every step of the way.
+
+This is a one-hour session where we explore the ideas in your proposal, scope out the concepts and outcomes that the collection is delivering, and gain a mutually clear understanding of what you will teach.
+
+Now that we’ve got a scope and plan for producing a collection of related lessons, it’s time to plan the example code that you will be teaching from. The example code provides a basis for the full scope of the collection, so we will be keeping it simple and achievable.
 
 ## Week 4: Start recording lessons for your collection
 
 Your collection is scoped.
 
-You've published several egghead lessons.
+You’ve published several egghead lessons.
 
 You sound great through your professional audio equipment.
 
-Now it's time to record! 🤗
+Now it’s time to record! 🤗
 
 This is the final week and the goal is to record and publish your collection.
 
-What's next?
+What’s next?
 
-After week 4, **you can expect us to be there at every step of the way to help you** publish lessons, collections, workshops, and courses. We work on your schedule, and strive to support you as much as possible. Check out [these case studies](/instructor/case-studies) to get an idea of how we've collaborated with other instructors to help them achieve their goals as educators and entrepreneurs.
+After week 4, **you can expect us to be there at every step of the way to help you** publish lessons, collections, workshops, and courses. We work on your schedule and strive to support you as much as possible. Check out [these case studies](/instructor/case-studies) to get an idea of how we’ve collaborated with other instructors to help them achieve their goals as educators and entrepreneurs.
 
-We look forward to working with YOU on YOUR [case study](https://howtoegghead.com/instructor/case-studies/)! 😀
+We look forward to working with YOU on YOUR [case study](/instructor/case-studies/)! 😄
 
 We will get you invited to Basecamp and our first group chat so we can discuss what to expect and meet the other instructors that will be participating this month as well.
 
-We're excited to collaborate with you.
+We’re excited to collaborate with you!


### PR DESCRIPTION
@laurosilvacom and I revised the Instructor Cohort Timeline copy to reflect the upcoming august cohort tasks.

The significant change we are making is turning the general-purpose, weekly 'office hours' into learning events that have clear objectives and outcomes. 

We also adjusted the language to be more explicit about the weekly lesson publishing that we expect because that was a bit of confusion in previous cohorts. 