### PR TITLE
Update colume size to 2 columns

### DIFF
--- a/content/instructor/case-studies/index.mdx
+++ b/content/instructor/case-studies/index.mdx
@@ -20,7 +20,7 @@ import Maggie from './maggie-appleton/images/maggie.png'
 
 export default ({ children, ...props }) => <div {...props}>{children}</div>
 
-<Grid gap={0} columns={props.columns || 1}>
+<Grid gap={0} columns={props.columns || 2}>
 
 <Card variant="primary" href="/instructor/case-studies/john-lindquist">
 <img src={John} />


### PR DESCRIPTION
The list was getting quite long on the [Case Study page](https://howtoegghead.com/instructor/case-studies/). Updating to 2 columns does the trick

# Before
<img width="340" alt="Image 2020-09-08 at 11 08 39 AM" src="https://user-images.githubusercontent.com/6188161/92495338-ca693d00-f1c4-11ea-94e4-ead1e9d20694.png">

# After
<img width="788" alt="Image 2020-09-08 at 11 09 08 AM" src="https://user-images.githubusercontent.com/6188161/92495351-ce955a80-f1c4-11ea-897e-f6083888e9a4.png">

![](https://media0.giphy.com/media/3WdUt1PX5mlSo/giphy.gif)