### PR TITLE
Add links to guide and screencast series to instructor guide

### DIFF
--- a/content/instructor/getting-started/index.mdx
+++ b/content/instructor/getting-started/index.mdx
@@ -139,7 +139,7 @@ We can't help you with your busy schedule. ;)
 
 It's to be expected though, because that's the type of folks we work with. Smart professionals are **always** busy. Creating egghead lessons is an aspect of your career, and in our experience can be treated as such. That means you have to make time to create egghead content, as it is impossible to find the time.
 
-And creating screencasts **is hard af**. For everybody. Particularly when you just start. Read the guide. Watch this video series. Scroll through this list of expert level time saving tips.
+And creating screencasts **is hard af**. For everybody. Particularly when you just start. [Read the guide](https://howtoegghead.com/instructor/screencasting/). [Watch this video series](https://egghead.io/courses/record-badass-screencasts-for-egghead-io). Scroll through this list of expert level time saving tips.
 
 We're here to help. If you're feeling stuck, send your coaches an email, message us in Slack, or schedule a time to chat on Zoom.
 


### PR DESCRIPTION
Hello,

I hope you don't mind me raising this PR, I was going through the [Getting started guide for instructors](https://howtoegghead.com/instructor/getting-started/) and noticed that there might be some missing links on the "is hard af" section.

I've tried to search for the time-saving tips, but couldn't find the resource yet 🤔 

