### PR TITLE
docs: fixing resolution typo in page

### DIFF
--- a/content/instructor/instructor-feedback-cycles/screen-setup/recording-lessons-in-hidpi-mode/index.mdx
+++ b/content/instructor/instructor-feedback-cycles/screen-setup/recording-lessons-in-hidpi-mode/index.mdx
@@ -1,7 +1,7 @@
 ---
 date: 2020-07-24
-title: 'Recording Lessons in HiDPI Mode (1028x720 pixels)'
-description: 'Recording Lessons in HiDPI Mode (1028x720 pixels)'
+title: 'Recording Lessons in HiDPI Mode (1280x720 pixels)'
+description: 'Recording Lessons in HiDPI Mode (1280x720 pixels)'
 categories: ['instructor']
 published: true
 shareImage: 'https://res.cloudinary.com/dg3gyk0gu/image/upload/v1571260698/og-image-assets/share_image_getting_started.png'


### PR DESCRIPTION
The page describes the resolution should be `1280x720 HiDPI`, but it shares `1028x720 HiDPI` on the title and metatag. This change should solve that