### PR TITLE
Fix typos in advocate section

### DIFF
--- a/content/advocate/index.mdx
+++ b/content/advocate/index.mdx
@@ -38,4 +38,4 @@ In live remote workshops the learner advocate "breaks the ice" by asking the "du
 
 egghead wants to produce badass workshops that help people. It can be difficult to get active participants in workshops.
 
-Paying people who are already learning in public, to attend and amplify the the learning experience will help all learners achieve their desired outcomes.
+Paying people who are already learning in public, to attend and amplify the learning experience will help all learners achieve their desired outcomes.

--- a/content/advocate/workshops/index.mdx
+++ b/content/advocate/workshops/index.mdx
@@ -8,7 +8,7 @@ published: true
 
 Learner Advocates are at the front lines in egghead livestreams events. They show up and actively participate. Lots of times people are afraid to ask questions they want to be looked at a certain way. You're the example to show other attendees it's ok to ask questions 
 
-Actively Participate some of these activities:
+Actively participate in some of these activities:
 
 * Ask the questions in the chat or on video
 * Take really good notes
@@ -18,7 +18,7 @@ Actively Participate some of these activities:
 
 In workshops some people are afraid to ask questions. Usually people are more comfortable asking questions when they see others doing so. 
 
-As a Learner Advocate you are there to make everyone else comfortable asking questions and learn from the material. Once everyone is asking good questions without fear of being judged it enhances everyone's experience! 
+As a Learner Advocate you are there to make everyone else comfortable asking questions and learning from the material. Once everyone is asking good questions without fear of being judged it enhances everyone's experience! 
 
 It also helps the instructor as well, when they ask "Does anyone have any questions?" and no one says anything they aren't able to get feedback to improve the workshop.
 
@@ -31,7 +31,7 @@ Asking questions on video as to the personalization of the workshop. It's not ma
 
 Take notes as you can. These will usually be light and not ultra detailed. We are aware it can be difficult to take great notes live.  
 
-Notes for the live workshops will be put in a GitHub repo and be used for feedback for the instructor. Including questions from attendees their answer would be great as well.
+Notes for the live workshops will be put in a GitHub repo and be used for feedback for the instructor. Including questions from attendees, their answer would be great as well.
 
 ## Providing Links to Resources 
 
@@ -39,4 +39,4 @@ When an instructor mentions a blog post, podcast, conference talks, book, etc, t
 
 You can also post the link to the Github repo we might be working out of, or any links to tools that might need to be downloaded. This let's the other learners focus on learning and the instructors on instructing.
 
-Ideally we would like to 3 Learner Advocates per workshop and these duties can be split and not overwhelm you.
+Ideally we would like to have 3 Learner Advocates per workshop and these duties can be split and not overwhelm you.


### PR DESCRIPTION
Came across the extra "the" in the index for the advocate page and when I was making the commit I thought about adding some readability improvements for the "workshops" section. 

The link to edit on GH made it easy for me sooo 😄