### PR TITLE
docs(vscode): removing minor distractions

### DIFF
--- a/content/instructor/screencasting/vscode/index.mdx
+++ b/content/instructor/screencasting/vscode/index.mdx
@@ -24,5 +24,8 @@ Here are some more settings that help remove some of the distractions:
 "editor.quickSuggestionsDelay": 1000000,
 "editor.parameterHints.enabled": false,
 "gitlens.mode.active": "zen",
-"editor.lightbulb.enabled": false
+"editor.lightbulb.enabled": false,
+"breadcrumbs.enabled": false,
+"workbench.activityBar.visible": false,
+"workbench.statusBar.visible": false
 ```

--- a/content/instructor/screencasting/vscode/index.mdx
+++ b/content/instructor/screencasting/vscode/index.mdx
@@ -22,5 +22,7 @@ Here are some more settings that help remove some of the distractions:
 "editor.suggestOnTriggerCharacters": false,
 "editor.wordBasedSuggestions": false,
 "editor.quickSuggestionsDelay": 1000000,
-"editor.parameterHints.enabled": false
+"editor.parameterHints.enabled": false,
+"gitlens.mode.active": "zen",
+"editor.lightbulb.enabled": false
 ```


### PR DESCRIPTION
- Using Gitlens in Zen mode, so it won't display git information when recording
- Disabling Code Editor Lightbulb in the editor
- Hiding Status Bar
- Hiding Breadcrumbs
- Hiding Activity Bar