### PR TITLE
update "is a lesson" to be one link instead of two

### DIFF
--- a/content/instructor/style-guide/what-to-teach/index.mdx
+++ b/content/instructor/style-guide/what-to-teach/index.mdx
@@ -61,7 +61,7 @@ _“How do I build an app with Ruby”_
 
 You’ll need a few days to cover that one. Think much smaller, and dive into a topic you can thoroughly cover in a few minutes, like:
 
-_“How do I create a component with React on Rails?”_ That can be a lesson. In fact, it [_is_](https://egghead.io/lessons/react-creating-a-component-with-react-on-rails) [a lesson](https://egghead.io/lessons/react-creating-a-component-with-react-on-rails).
+_“How do I create a component with React on Rails?”_ That can be a lesson. In fact, it [is a lesson](https://egghead.io/lessons/react-creating-a-component-with-react-on-rails).
 
 ### Write it and code it
 


### PR DESCRIPTION
I don't believe this was intentional as they both point at the same link.

Happy to be wrong, but thought this was a decent place to start.